### PR TITLE
CI for Test Suite

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,7 +83,7 @@ Singularity Image Build:
   script:
     - docker build --no-cache -f docker/Dockerfile.finn --tag=finn_docker_export .
     - apptainer build finn_singularity_image.sif docker-daemon://finn_docker_export:latest
-    - rsync -vh finn_singularity_image.sif $PATH_SINGULARITY_IMG_BUILD/finn-plus/finn_$CI_COMMIT_REF_NAME.sif
+    - rsync -vh finn_singularity_image.sif $PATH_SINGULARITY_IMG_BUILD/finn-plus/finn_$CI_COMMIT_REF_SLUG.sif
   after_script: # Clean caches
     - echo 'y' | docker image prune
     - echo 'y' | docker builder prune
@@ -107,7 +107,7 @@ FINN Test Suite 2022.2:
           - docker/quicktest.sh
         compare_to: "dev"
       variables:
-        SINGULARITY_IMG_SELECT: "finn_$CI_COMMIT_REF_NAME.sif"
+        SINGULARITY_IMG_SELECT: "finn_$CI_COMMIT_REF_SLUG.sif"
     # Always run, as long as there was no prior failure
     - when: on_success
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,102 @@
+stages:
+  - update
+  - build
+  - test
+
+variables:
+  TEST_SUITE:
+    description: "Select test suite to run"
+    value: "quicktest"
+    options:
+      - "quicktest"
+      - "main"
+      - "rtlsim"
+      - "end2end"
+      - "full"
+  CPU_CORES:
+    description: "Select number of CPU cores and test workers"
+    value: "8"
+  SLURM_TIMEOUT:
+    description: "Select SLURM timeout"
+    value: "0-24" # [days-hours]
+
+workflow:
+  rules:
+    # Special handling for TEST_SUITE value "quicktest"
+    - if: $TEST_SUITE == "quicktest"
+      variables:
+        SLURM_TIMEOUT: "0-1" # Reduce timeout to 1 hour
+    # Run pipeline for all default sources
+    - when: always
+
+Sync finn-dev:
+  id_tokens:
+    CI_JOB_JWT:
+      aud: https://git.uni-paderborn.de
+  stage: update
+  tags:
+    # Run where full Docker + Singularity is available
+    - image_build
+  rules:
+    # Only run on a schedule
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+  script:
+    - mkdir -p ../github_clone && cd ../github_clone
+    - rm -rf finn-plus # Ensure we do a fresh clone (TODO: better way to handle this on job level?)
+    - git clone git@github.com:eki-project/finn-plus.git && cd finn-plus
+    - git remote add upstream https://github.com/Xilinx/finn.git
+    - git checkout finn-dev
+    - git pull upstream dev
+    - git push origin finn-dev
+
+Singularity Image Build:
+  id_tokens:
+    CI_JOB_JWT:
+      aud: https://git.uni-paderborn.de
+  stage: build
+  tags:
+    # Run where full Docker + Singularity is available
+    - image_build
+  rules:
+    # Do not run on a schedule
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: never
+    # Only run if relevant files changed
+    - changes:
+      - requirements.txt
+      - docker/Dockerfile.finn
+      - docker/finn_entrypoint.sh
+      - docker/quicktest.sh
+  before_script:
+    - FINN_SHA_SHORT=$(git rev-parse --short HEAD)
+  script:
+    - docker build --no-cache -f docker/Dockerfile.finn --tag=finn_docker_export .
+    - apptainer build finn_singularity_image.sif docker-daemon://finn_docker_export:latest
+    - rsync -vh finn_singularity_image.sif $PATH_SINGULARITY_IMG_BUILD/finn-plus/finn_dev.sif
+    - rsync -vh finn_singularity_image.sif $PATH_SINGULARITY_IMG_BUILD/finn-plus/finn_$FINN_SHA_SHORT.sif
+  after_script: # Clean caches
+    - echo 'y' | docker image prune
+    - echo 'y' | docker builder prune
+    - echo 'y' | apptainer cache clean
+
+FINN Test Suite:
+  id_tokens:
+    CI_JOB_JWT:
+      aud: https://git.uni-paderborn.de
+  stage: test
+  rules:
+    # Do not run on a schedule
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: never
+    # Otherwise run if there was no prior failure
+    - when: on_success
+  variables:
+    SCHEDULER_PARAMETERS: "-A $PROJECT_ACCOUNT -p normal -t $SLURM_TIMEOUT --nodes 1 --ntasks 1 --cpus-per-task $CPU_CORES --mem 128G"
+    PYTEST_PARALLEL: "$CPU_CORES"
+    FINN_SINGULARITY: "$PATH_SINGULARITY_IMG/finn-plus/finn_dev.sif"
+  before_script:
+    - cp -dfR .. $PATH_WORKDIR # Copy to working directory (e.g. RAMdisk)
+    - cd $PATH_WORKDIR/finn-plus
+    - module load system singularity
+  script:
+    - ./run-docker.sh quicktest.sh $TEST_SUITE

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,7 +79,7 @@ Singularity Image Build:
     - echo 'y' | docker builder prune
     - echo 'y' | apptainer cache clean
 
-FINN Test Suite:
+FINN Test Suite 2022.2:
   id_tokens:
     CI_JOB_JWT:
       aud: https://git.uni-paderborn.de
@@ -94,9 +94,15 @@ FINN Test Suite:
     SCHEDULER_PARAMETERS: "-A $PROJECT_ACCOUNT -p normal -t $SLURM_TIMEOUT --nodes 1 --ntasks 1 --cpus-per-task $CPU_CORES --mem 128G"
     PYTEST_PARALLEL: "$CPU_CORES"
     FINN_SINGULARITY: "$PATH_SINGULARITY_IMG/finn-plus/finn_dev.sif"
+    FINN_XILINX_VERSION: "2022.2"
   before_script:
     - cp -dfR .. $PATH_WORKDIR # Copy to working directory (e.g. RAMdisk)
     - cd $PATH_WORKDIR/finn-plus
     - module load system singularity
   script:
     - ./run-docker.sh quicktest.sh $TEST_SUITE
+
+FINN Test Suite 2024.1:
+  extends: FINN Test Suite 2022.2
+  variables:
+    FINN_XILINX_VERSION: "2024.1"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -91,7 +91,7 @@ FINN Test Suite 2022.2:
     # Otherwise run if there was no prior failure
     - when: on_success
   variables:
-    SCHEDULER_PARAMETERS: "-A $PROJECT_ACCOUNT -p normal -t $SLURM_TIMEOUT --nodes 1 --ntasks 1 --cpus-per-task $CPU_CORES --mem 128G"
+    SCHEDULER_PARAMETERS: "-A $PROJECT_ACCOUNT -p normal -t $SLURM_TIMEOUT --nodes 1 --ntasks 1 --cpus-per-task $CPU_CORES --mem 192G --exclusive"
     PYTEST_PARALLEL: "$CPU_CORES"
     FINN_SINGULARITY: "$PATH_SINGULARITY_IMG/finn-plus/finn_dev.sif"
     FINN_XILINX_VERSION: "2022.2"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,12 @@ variables:
   SLURM_TIMEOUT:
     description: "Select SLURM timeout"
     value: "3-0" # [days-hours]
+  SLURM_PARTITION:
+    description: "Slurm partition (e.g., normal, largemem, fpga, gpu)"
+    value: "normal"
+  SLURM_QOS:
+    description: "Optional QoS option (include --qos, e.g., --qos express)"
+    value: ""
 
 workflow:
   rules:
@@ -91,7 +97,7 @@ FINN Test Suite 2022.2:
     # Otherwise run if there was no prior failure
     - when: on_success
   variables:
-    SCHEDULER_PARAMETERS: "-A $PROJECT_ACCOUNT -p normal -t $SLURM_TIMEOUT --nodes 1 --ntasks 1 --cpus-per-task $CPU_CORES --exclusive"
+    SCHEDULER_PARAMETERS: "-A $PROJECT_ACCOUNT -p $SLURM_PARTITION -t $SLURM_TIMEOUT $SLURM_QOS --nodes 1 --ntasks 1 --cpus-per-task $CPU_CORES --exclusive"
     PYTEST_PARALLEL: "$CPU_CORES"
     FINN_SINGULARITY: "$PATH_SINGULARITY_IMG/finn-plus/finn_dev.sif"
     FINN_XILINX_VERSION: "2022.2"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,12 +74,12 @@ Singularity Image Build:
       when: never
     # Only run if relevant files changed relative to dev branch
     - changes:
-      paths:
-        - requirements.txt
-        - docker/Dockerfile.finn
-        - docker/finn_entrypoint.sh
-        - docker/quicktest.sh
-      compare_to: "dev"
+        paths:
+          - requirements.txt
+          - docker/Dockerfile.finn
+          - docker/finn_entrypoint.sh
+          - docker/quicktest.sh
+        compare_to: "dev"
   script:
     - docker build --no-cache -f docker/Dockerfile.finn --tag=finn_docker_export .
     - apptainer build finn_singularity_image.sif docker-daemon://finn_docker_export:latest
@@ -107,8 +107,8 @@ FINN Test Suite 2022.2:
           - docker/finn_entrypoint.sh
           - docker/quicktest.sh
         compare_to: "dev"
-        variables:
-          SINGULARITY_IMG_SELECT: "finn_$CI_COMMIT_SHORT_SHA.sif"
+      variables:
+        SINGULARITY_IMG_SELECT: "finn_$CI_COMMIT_SHORT_SHA.sif"
     # Always run, as long as there was no prior failure
     - when: on_success
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,15 +30,15 @@ variables:
 
 workflow:
   rules:
-    # Run pipeline for GitHub PRs (does not support PRs from forks)
-    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event"
+    # Run pipeline for GitHub PRs to dev (does not support PRs from forks)
+    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" && $CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME == "dev"
+    # Run pipeline for pushes to dev
+    - if: $CI_COMMIT_BRANCH == "dev"
     # Run pipeline if manually triggered via API or web GUI
     - if: $CI_PIPELINE_SOURCE == "api"
     - if: $CI_PIPELINE_SOURCE == "web"
     # Run pipeline if scheduled (only for nightly sync of finn-dev)
     - if: $CI_PIPELINE_SOURCE == "schedule"
-    # Run pipeline for pushes to dev branch
-    - if: $CI_COMMIT_BRANCH == "dev"
 
 Sync finn-dev:
   id_tokens:
@@ -84,7 +84,6 @@ Singularity Image Build:
     - docker build --no-cache -f docker/Dockerfile.finn --tag=finn_docker_export .
     - apptainer build finn_singularity_image.sif docker-daemon://finn_docker_export:latest
     - rsync -vh finn_singularity_image.sif $PATH_SINGULARITY_IMG_BUILD/finn-plus/finn_$CI_COMMIT_REF_NAME.sif
-    - rsync -vh finn_singularity_image.sif $PATH_SINGULARITY_IMG_BUILD/finn-plus/finn_$CI_COMMIT_SHORT_SHA.sif
   after_script: # Clean caches
     - echo 'y' | docker image prune
     - echo 'y' | docker builder prune
@@ -108,7 +107,7 @@ FINN Test Suite 2022.2:
           - docker/quicktest.sh
         compare_to: "dev"
       variables:
-        SINGULARITY_IMG_SELECT: "finn_$CI_COMMIT_SHORT_SHA.sif"
+        SINGULARITY_IMG_SELECT: "finn_$CI_COMMIT_REF_NAME.sif"
     # Always run, as long as there was no prior failure
     - when: on_success
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ stages:
 variables:
   TEST_SUITE:
     description: "Select test suite to run"
-    value: "quicktest"
+    value: "full"
     options:
       - "quicktest"
       - "main"
@@ -18,7 +18,7 @@ variables:
     value: "8"
   SLURM_TIMEOUT:
     description: "Select SLURM timeout"
-    value: "0-24" # [days-hours]
+    value: "3-0" # [days-hours]
 
 workflow:
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,7 +82,7 @@ Singularity Image Build:
         compare_to: "dev"
   script:
     - docker build --no-cache -f docker/Dockerfile.finn --tag=finn_docker_export .
-    - apptainer build finn_singularity_image.sif docker-daemon://finn_docker_export:latest
+    - apptainer build --force finn_singularity_image.sif docker-daemon://finn_docker_export:latest
     - rsync -vh finn_singularity_image.sif $PATH_SINGULARITY_IMG_BUILD/finn-plus/finn_$CI_COMMIT_REF_SLUG.sif
   after_script: # Clean caches
     - echo 'y' | docker image prune

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -91,7 +91,7 @@ FINN Test Suite 2022.2:
     # Otherwise run if there was no prior failure
     - when: on_success
   variables:
-    SCHEDULER_PARAMETERS: "-A $PROJECT_ACCOUNT -p normal -t $SLURM_TIMEOUT --nodes 1 --ntasks 1 --cpus-per-task $CPU_CORES --mem 192G --exclusive"
+    SCHEDULER_PARAMETERS: "-A $PROJECT_ACCOUNT -p normal -t $SLURM_TIMEOUT --nodes 1 --ntasks 1 --cpus-per-task $CPU_CORES --exclusive"
     PYTEST_PARALLEL: "$CPU_CORES"
     FINN_SINGULARITY: "$PATH_SINGULARITY_IMG/finn-plus/finn_dev.sif"
     FINN_XILINX_VERSION: "2022.2"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 stages:
-  - update
-  - build
+  - sync
+  - singularity_build
   - test
 
 variables:
@@ -25,21 +25,26 @@ variables:
   SLURM_QOS:
     description: "Optional QoS option (include --qos, e.g., --qos express)"
     value: ""
+  SINGULARITY_IMG_SELECT:
+    value: "finn_dev.sif"
 
 workflow:
   rules:
-    # Special handling for TEST_SUITE value "quicktest"
-    - if: $TEST_SUITE == "quicktest"
-      variables:
-        SLURM_TIMEOUT: "0-1" # Reduce timeout to 1 hour
-    # Run pipeline for all default sources
-    - when: always
+    # Run pipeline for GitHub PRs (does not support PRs from forks)
+    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event"
+    # Run pipeline if manually triggered via API or web GUI
+    - if: $CI_PIPELINE_SOURCE == "api"
+    - if: $CI_PIPELINE_SOURCE == "web"
+    # Run pipeline if scheduled (only for nightly sync of finn-dev)
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    # Run pipeline for pushes to dev branch
+    - if: $CI_COMMIT_BRANCH == "dev"
 
 Sync finn-dev:
   id_tokens:
     CI_JOB_JWT:
       aud: https://git.uni-paderborn.de
-  stage: update
+  stage: sync
   tags:
     # Run where full Docker + Singularity is available
     - image_build
@@ -59,7 +64,7 @@ Singularity Image Build:
   id_tokens:
     CI_JOB_JWT:
       aud: https://git.uni-paderborn.de
-  stage: build
+  stage: singularity_build
   tags:
     # Run where full Docker + Singularity is available
     - image_build
@@ -67,19 +72,19 @@ Singularity Image Build:
     # Do not run on a schedule
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: never
-    # Only run if relevant files changed
+    # Only run if relevant files changed relative to dev branch
     - changes:
-      - requirements.txt
-      - docker/Dockerfile.finn
-      - docker/finn_entrypoint.sh
-      - docker/quicktest.sh
-  before_script:
-    - FINN_SHA_SHORT=$(git rev-parse --short HEAD)
+      paths:
+        - requirements.txt
+        - docker/Dockerfile.finn
+        - docker/finn_entrypoint.sh
+        - docker/quicktest.sh
+      compare_to: "dev"
   script:
     - docker build --no-cache -f docker/Dockerfile.finn --tag=finn_docker_export .
     - apptainer build finn_singularity_image.sif docker-daemon://finn_docker_export:latest
-    - rsync -vh finn_singularity_image.sif $PATH_SINGULARITY_IMG_BUILD/finn-plus/finn_dev.sif
-    - rsync -vh finn_singularity_image.sif $PATH_SINGULARITY_IMG_BUILD/finn-plus/finn_$FINN_SHA_SHORT.sif
+    - rsync -vh finn_singularity_image.sif $PATH_SINGULARITY_IMG_BUILD/finn-plus/finn_$CI_COMMIT_REF_NAME.sif
+    - rsync -vh finn_singularity_image.sif $PATH_SINGULARITY_IMG_BUILD/finn-plus/finn_$CI_COMMIT_SHORT_SHA.sif
   after_script: # Clean caches
     - echo 'y' | docker image prune
     - echo 'y' | docker builder prune
@@ -94,12 +99,22 @@ FINN Test Suite 2022.2:
     # Do not run on a schedule
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: never
-    # Otherwise run if there was no prior failure
+    # Select different Singularity image if it deviates from default (dev branch)
+    - changes:
+        paths:
+          - requirements.txt
+          - docker/Dockerfile.finn
+          - docker/finn_entrypoint.sh
+          - docker/quicktest.sh
+        compare_to: "dev"
+        variables:
+          SINGULARITY_IMG_SELECT: "finn_$CI_COMMIT_SHORT_SHA.sif"
+    # Always run, as long as there was no prior failure
     - when: on_success
   variables:
     SCHEDULER_PARAMETERS: "-A $PROJECT_ACCOUNT -p $SLURM_PARTITION -t $SLURM_TIMEOUT $SLURM_QOS --nodes 1 --ntasks 1 --cpus-per-task $CPU_CORES --exclusive"
     PYTEST_PARALLEL: "$CPU_CORES"
-    FINN_SINGULARITY: "$PATH_SINGULARITY_IMG/finn-plus/finn_dev.sif"
+    FINN_SINGULARITY: "$PATH_SINGULARITY_IMG/finn-plus/$SINGULARITY_IMG_SELECT"
     FINN_XILINX_VERSION: "2022.2"
   before_script:
     - cp -dfR .. $PATH_WORKDIR # Copy to working directory (e.g. RAMdisk)

--- a/docker/quicktest.sh
+++ b/docker/quicktest.sh
@@ -12,7 +12,8 @@ elif [ $1 = "main" ]; then
   pytest -k 'not (rtlsim or end2end)' --dist=loadfile -n $PYTEST_PARALLEL
 elif [ $1 = "rtlsim" ]; then
   echo "Running rtlsim test suite with pytest-parallel"
-  pytest -k rtlsim --workers $PYTEST_PARALLEL
+# there are end2end tests which also have rtlsim in their name, but not vice versa
+  pytest -k 'rtlsim and not end2end' --workers $PYTEST_PARALLEL
 elif [ $1 = "end2end" ]; then
   echo "Running end2end test suite with no parallelism"
 # filtering by name "end2end" is not sufficient, as the bnn tests need to be selected by a marker

--- a/docker/quicktest.sh
+++ b/docker/quicktest.sh
@@ -4,7 +4,7 @@
 
 cd $FINN_ROOT
 # check if command line argument is empty or not present
-if [ -z $1 ]; then
+if [ -z $1 ] || [ $1 = "quicktest" ]; then
   echo "Running quicktest: not (vivado or slow or board) with pytest-xdist"
   pytest -m 'not (vivado or slow or vitis or board or notebooks or bnn_pynq)' --dist=loadfile -n $PYTEST_PARALLEL
 elif [ $1 = "main" ]; then
@@ -22,5 +22,5 @@ elif [ $1 = "full" ]; then
   $0 rtlsim;
   $0 end2end;
 else
-  echo "Unrecognized argument to quicktest.sh"
+  echo "Unrecognized argument to quicktest.sh: $1"
 fi

--- a/docker/quicktest.sh
+++ b/docker/quicktest.sh
@@ -15,7 +15,8 @@ elif [ $1 = "rtlsim" ]; then
   pytest -k rtlsim --workers $PYTEST_PARALLEL
 elif [ $1 = "end2end" ]; then
   echo "Running end2end test suite with no parallelism"
-  pytest -k end2end
+# filtering by name "end2end" is not sufficient, as the bnn tests need to be selected by a marker
+  pytest -k end2end -m 'sanity_bnn or end2end or fpgadataflow or notebooks'
 elif [ $1 = "full" ]; then
   echo "Running full test suite, each step with appropriate parallelism"
   $0 main;

--- a/docker/quicktest.sh
+++ b/docker/quicktest.sh
@@ -6,18 +6,18 @@ cd $FINN_ROOT
 # check if command line argument is empty or not present
 if [ -z $1 ] || [ $1 = "quicktest" ]; then
   echo "Running quicktest: not (vivado or slow or board) with pytest-xdist"
-  pytest -m 'not (vivado or slow or vitis or board or notebooks or bnn_pynq)' --dist=loadfile -n $PYTEST_PARALLEL
+  pytest -m 'not (vivado or slow or vitis or board or notebooks or bnn_pynq)' --forked --dist=loadfile -n $PYTEST_PARALLEL
 elif [ $1 = "main" ]; then
   echo "Running main test suite: not (rtlsim or end2end) with pytest-xdist"
-  pytest -k 'not (rtlsim or end2end)' --dist=loadfile -n $PYTEST_PARALLEL
+  pytest -k 'not (rtlsim or end2end)' --forked --dist=loadfile -n $PYTEST_PARALLEL
 elif [ $1 = "rtlsim" ]; then
   echo "Running rtlsim test suite with pytest-parallel"
 # there are end2end tests which also have rtlsim in their name, but not vice versa
-  pytest -k 'rtlsim and not end2end' --workers $PYTEST_PARALLEL
+  pytest -k 'rtlsim and not end2end' --forked --workers $PYTEST_PARALLEL
 elif [ $1 = "end2end" ]; then
   echo "Running end2end test suite with no parallelism"
 # filtering by name "end2end" is not sufficient, as the bnn tests need to be selected by a marker
-  pytest -k end2end -m 'sanity_bnn or end2end or fpgadataflow or notebooks'
+  pytest -k end2end --forked -m 'sanity_bnn or end2end or fpgadataflow or notebooks'
 elif [ $1 = "full" ]; then
   echo "Running full test suite, each step with appropriate parallelism"
   $0 main;

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ pre-commit==3.3.2
 protobuf==3.20.3
 psutil==5.9.4
 pyscaffold==4.4
+pytest-forked==1.6.0
 scipy==1.10.1
 setupext-janitor>=1.1.2
 sigtools==4.0.1


### PR DESCRIPTION
Adds base GitLab CI featuring:

- Nightly sync of finn-dev branch
- Build of Singularity image (only upon change of relevant files)
- FINN test suite

Another PR with CI for my benchmarking suite will follow.

TODO:
- [x] Extend to full test suite
- [ ] Ensure all tests pass
- [x] Test for both 2022.2 and 2024.2 (2024.1 for now as 2024.2 is not installed yet)
- [x] Only run on PR
- [x] Ensure correct Singularity image is always built and used
- [x] Switch pipeline schedule back to dev once merged