### PR TITLE
Updated flake version to fix incorrect flake error E231

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
     args: [--line-length=100]
 
 - repo: https://github.com/PyCQA/flake8
-  rev: 6.0.0
+  rev: 6.1.0
   hooks:
   - id: flake8
     # black-compatible flake-8 config

--- a/src/finn/util/data_packing.py
+++ b/src/finn/util/data_packing.py
@@ -59,7 +59,7 @@ def array2hexstring(array, dtype, pad_to_nbits, prefix="0x", reverse=False):
     if pad_to_nbits < 4:
         pad_to_nbits = 4
     # ensure input is a numpy array with float values
-    if type(array) != np.ndarray or array.dtype != np.float32:
+    if type(array) is not np.ndarray or array.dtype != np.float32:
         # try to convert to a float numpy array (container dtype is float)
         array = np.asarray(array, dtype=np.float32)
     # ensure one-dimensional array to pack
@@ -144,7 +144,7 @@ def pack_innermost_dim_as_hex_string(
     pack_innermost_dim_as_hex_string(B, DataType["UINT2"], 8) == eB
     """
 
-    if type(ndarray) != np.ndarray or ndarray.dtype != np.float32:
+    if type(ndarray) is not np.ndarray or ndarray.dtype != np.float32:
         # try to convert to a float numpy array (container dtype is float)
         ndarray = np.asarray(ndarray, dtype=np.float32)
 
@@ -162,7 +162,7 @@ def unpack_innermost_dim_from_hex_string(
     such that any padding in the packing dimension is removed. If reverse_inner
     is set, the innermost unpacked dimension will be reversed."""
 
-    if type(ndarray) != np.ndarray:
+    if type(ndarray) is not np.ndarray:
         raise Exception(
             """unpack_innermost_dim_from_hex_string needs ndarray
         as input"""
@@ -239,7 +239,7 @@ def numpy_to_hls_code(ndarray, dtype, hls_var_name, pack_innermost_dim=True, no_
     emitted string.
     """
     hls_dtype = dtype.get_hls_datatype_str()
-    if type(ndarray) != np.ndarray or ndarray.dtype != np.float32:
+    if type(ndarray) is not np.ndarray or ndarray.dtype != np.float32:
         # try to convert to a float numpy array (container dtype is float)
         ndarray = np.asarray(ndarray, dtype=np.float32)
     if pack_innermost_dim:
@@ -261,9 +261,9 @@ def numpy_to_hls_code(ndarray, dtype, hls_var_name, pack_innermost_dim=True, no_
     # define a function to convert a single element into a C++ init string
     # a single element can be a hex string if we are using packing
     def elem2str(x):
-        if type(x) == str or type(x) == np.str_:
+        if type(x) is str or type(x) is np.str_:
             return '%s("%s", 16)' % (hls_dtype, x)
-        elif type(x) == np.float32:
+        elif type(x) is np.float32:
             if dtype.is_integer():
                 return str(int(x))
             else:


### PR DESCRIPTION
As the title says, flake incorrectly flags fstrings such as:
```Python
s = f"{a}:1:{b}"
```
with an E231 error which requires you to insert whitespaces around : , ;  etc.
This only occurs in Python 3.12 and below flake 6.1.0 apparently. FINN currently is on Python 3.10 but we still might want to fix this beforehand or if anyone uses a 3.12 dev environment.