### PR TITLE
[Lookup] Relax input datatype constraints

### DIFF
--- a/src/finn/custom_op/fpgadataflow/hls/lookup_hls.py
+++ b/src/finn/custom_op/fpgadataflow/hls/lookup_hls.py
@@ -273,7 +273,7 @@ class Lookup_hls(Lookup, HLSBackend):
             )
 
         inp = context[node.input[0]]
-        assert inp.dtype == np.int64, "Inputs must be contained in int64 ndarray"
+        # assert inp.dtype == np.int64, "Inputs must be contained in int64 ndarray"
         assert inp.shape == exp_ishape, """Input shape doesn't match expected shape."""
         export_idt = self.get_input_datatype()
         odt = self.get_output_datatype()

--- a/src/finn/custom_op/fpgadataflow/hls/lookup_hls.py
+++ b/src/finn/custom_op/fpgadataflow/hls/lookup_hls.py
@@ -28,6 +28,7 @@
 
 import numpy as np
 import os
+import warnings
 from math import ceil, log2
 from qonnx.core.datatype import DataType
 
@@ -273,7 +274,18 @@ class Lookup_hls(Lookup, HLSBackend):
             )
 
         inp = context[node.input[0]]
-        # assert inp.dtype == np.int64, "Inputs must be contained in int64 ndarray"
+
+        # Make sure the input has the right container datatype
+        if inp.dtype is not np.float32:
+            # Issue a warning to make the user aware of this type-cast
+            warnings.warn(
+                f"{node.name}: Changing input container datatype from "
+                f"{inp.dtype} to {np.float32}"
+            )
+            # Convert the input to floating point representation as the
+            # container datatype
+            inp = inp.astype(np.float32)
+
         assert inp.shape == exp_ishape, """Input shape doesn't match expected shape."""
         export_idt = self.get_input_datatype()
         odt = self.get_output_datatype()

--- a/src/finn/custom_op/fpgadataflow/rtl/streamingfifo_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/streamingfifo_rtl.py
@@ -133,10 +133,18 @@ class StreamingFIFO_rtl(StreamingFIFO, RTLBackend):
         elif mode == "rtlsim":
             code_gen_dir = self.get_nodeattr("code_gen_dir_ipgen")
             # create a npy file for the input of the node
-            assert (
-                str(inp.dtype) == "float32"
-            ), """Input datatype is
-                not float32 as expected."""
+
+            # Make sure the inpout has the right container datatype
+            if inp.dtype != np.float32:
+                # Issue a warning to make the user aware of this type-cast
+                warnings.warn(
+                    f"{node.name}: Changing input datatype from "
+                    f"{inp.dtype} to {np.float32}"
+                )
+                # Convert the input to floating point representation as the
+                # container datatype
+                inp = inp.astype(np.float32)
+
             expected_inp_shape = self.get_folded_input_shape()
             reshaped_input = inp.reshape(expected_inp_shape)
             if DataType[self.get_nodeattr("dataType")] == DataType["BIPOLAR"]:

--- a/src/finn/custom_op/fpgadataflow/rtl/streamingfifo_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/streamingfifo_rtl.py
@@ -134,11 +134,11 @@ class StreamingFIFO_rtl(StreamingFIFO, RTLBackend):
             code_gen_dir = self.get_nodeattr("code_gen_dir_ipgen")
             # create a npy file for the input of the node
 
-            # Make sure the inpout has the right container datatype
-            if inp.dtype != np.float32:
+            # Make sure the input has the right container datatype
+            if inp.dtype is not np.float32:
                 # Issue a warning to make the user aware of this type-cast
                 warnings.warn(
-                    f"{node.name}: Changing input datatype from "
+                    f"{node.name}: Changing input container datatype from "
                     f"{inp.dtype} to {np.float32}"
                 )
                 # Convert the input to floating point representation as the


### PR DESCRIPTION
FINN and QONNX generally assume float32 as the container datatype of tensors. However, Gather/Lookup export with int64 tensors as the index input, which makes more sense, but is not properly handled by our compiler infrastructure. Instead of refactoring container datatype handling throughout the code base, for now it seems to be sufficient to disable some assertions or at least relax them to warnings. A proper refactoring of the Lookup operator might be necessary in the near future anyway.

See mirror PR https://github.com/Xilinx/finn/pull/1267