### PR TITLE
[Deps] Switch to Christoph's Brevitas fork

### DIFF
--- a/fetch-repos.sh
+++ b/fetch-repos.sh
@@ -29,7 +29,7 @@
 
 QONNX_COMMIT="2281a777d84aa5cbd7469085c2e534fb4a03ccf9"
 FINN_EXP_COMMIT="0724be21111a21f0d81a072fccc1c446e053f851"
-BREVITAS_COMMIT="d4834bd2a0fad3c1fbc0ff7e1346d5dcb3797ea4"
+BREVITAS_COMMIT="34c350afde0a69b7a39b13eb4748b979bdae1eff"
 PYVERILATOR_COMMIT="ce0a08c20cb8c1d1e84181d6f392390f846adbd1"
 CNPY_COMMIT="4e8810b1a8637695171ed346ce68f6984e585ef4"
 HLSLIB_COMMIT="16e5847a5e3ef76cffe84c8fad2f010d593457d3"
@@ -42,7 +42,7 @@ EXP_BOARD_FILES_MD5="226ca927a16ea4ce579f1332675e9e9a"
 
 QONNX_URL="https://github.com/fastmachinelearning/qonnx.git"
 FINN_EXP_URL="https://github.com/Xilinx/finn-experimental.git"
-BREVITAS_URL="https://github.com/Xilinx/brevitas.git"
+BREVITAS_URL="https://github.com/iksnagreb/brevitas.git"
 PYVERILATOR_URL="https://github.com/maltanar/pyverilator.git"
 CNPY_URL="https://github.com/rogersce/cnpy.git"
 HLSLIB_URL="https://github.com/Xilinx/finn-hlslib.git"


### PR DESCRIPTION
Switch out Brevitas since we need some modifications to the Attention operator for our Transformer implementation.

@iksnagreb is there a newer commit we should pin? Do we need/want to synchronize with the latest Brevitas? We should be at least as current as Xilinx/finn/dev.