### PR TITLE
[Docker] Fix docker setup fail due to apt install failing 

### DIFF
--- a/docker/Dockerfile.finn
+++ b/docker/Dockerfile.finn
@@ -86,7 +86,7 @@ RUN if [ -z "$LOCAL_XRT" ] && [ -z "$SKIP_XRT" ];then \
 COPY requirements.txt $XRT_DEB_VERSION.* /tmp/
 
 RUN if [ -z "$SKIP_XRT" ];then \
-    apt install -y /tmp/$XRT_DEB_VERSION.deb && \
+    apt update && apt install -y /tmp/$XRT_DEB_VERSION.deb && \
     rm /tmp/$XRT_DEB_VERSION.deb; fi
 
 # versioned Python package requirements for FINN compiler


### PR DESCRIPTION
Sometimes when running locally, Docker fails when executing `apt install`. This might be because of a 404 when fetching dependencies and is (at least in my case) fixed by running `apt update` first.