### PR TITLE
Improve Test Suite CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -158,10 +158,11 @@ FINN Test Suite 2022.2:
   before_script:
     - cp -dfR .. $PATH_WORKDIR # Copy to working directory (e.g. RAMdisk)
     - cd $PATH_WORKDIR/finn-plus
+    - chmod 755 ./test.sh
     - module load system singularity
     - export FINN_SINGULARITY=$PATH_SINGULARITY_IMG/finn-plus/$SINGULARITY_IMG_SELECT
   script:
-    - ./run-docker.sh test.sh $TEST_SUITE
+    - ./run-docker.sh ./test.sh $TEST_SUITE
   artifacts:
     name: "test_reports"
     when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -141,8 +141,11 @@ FINN Test Suite 2022.2:
     # Do not run on a schedule
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: never
-    # Run if "full" test suite selected (and if previous jobs were successful)
-    - if: $TEST_SUITE == "full"
+    # Do not run if test suite has been deselected
+    - if: $TEST_SUITE == "none"
+      when: never
+    # Always run, as long as there was no prior failure
+    - when: on_success
   cache:
     key: $CI_COMMIT_SHA
     policy: pull
@@ -150,6 +153,7 @@ FINN Test Suite 2022.2:
       - deps
   variables:
     SCHEDULER_PARAMETERS: "-A $PROJECT_ACCOUNT -p $SLURM_PARTITION -t $SLURM_TIMEOUT $SLURM_QOS --nodes 1 --ntasks 1 --cpus-per-task $CPU_CORES --exclusive"
+    PYTEST_PARALLEL: "$CPU_CORES"
     FINN_XILINX_VERSION: "2022.2"
   before_script:
     - cp -dfR .. $PATH_WORKDIR # Copy to working directory (e.g. RAMdisk)
@@ -157,12 +161,7 @@ FINN Test Suite 2022.2:
     - module load system singularity
     - export FINN_SINGULARITY=$PATH_SINGULARITY_IMG/finn-plus/$SINGULARITY_IMG_SELECT
   script:
-    - ./run-docker.sh bash
-    - pytest -k 'not (rtlsim or end2end)' --junitxml=$CI_PROJECT_DIR/reports/main.xml --html=$CI_PROJECT_DIRreports/main.html --reruns 2 --forked --dist worksteal -n $CPU_CORES
-    - pytest -k 'rtlsim and not end2end' --junitxml=$CI_PROJECT_DIR/reports/rtlsim.xml --html=$CI_PROJECT_DIR/reports/rtlsim.html --reruns 2 --forked --dist worksteal -n $CPU_CORES
-    - pytest -k 'end2end' -m 'sanity_bnn or end2end or fpgadataflow or notebooks' --junitxml=$CI_PROJECT_DIR/reports/end2end.xml --html=$CI_PROJECT_DIR/reports/end2end.html --reruns 2 --forked --dist loadfile -n $CPU_CORES
-    - pytest_html_merger -i $CI_PROJECT_DIR/reports/ -o $CI_PROJECT_DIR/reports/full_test_suite.html
-    - exit
+    - ./run-docker.sh test.sh $TEST_SUITE
   artifacts:
     name: "test_reports"
     when: always
@@ -170,19 +169,6 @@ FINN Test Suite 2022.2:
       - reports/
     reports:
       junit: reports/*.xml
-
-FINN Test Suite Quick:
-  extends: FINN Test Suite 2022.2
-  rules:
-    # Do not run on a schedule
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-      when: never
-    # Run if "quick" test suite selected (and if previous jobs were successful)
-    - if: $TEST_SUITE == "quicktest"
-  script:
-    - ./run-docker.sh bash
-    - pytest -m 'not (vivado or slow or vitis or board or notebooks or bnn_pynq)' --junitxml=$CI_PROJECT_DIR/reports/quick.xml --html=$CI_PROJECT_DIR/reports/quick.html --reruns 2 --forked --dist worksteal -n $CPU_CORES
-    - exit
 
 FINN Test Suite 2024.1:
   extends: FINN Test Suite 2022.2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -178,7 +178,7 @@ FINN Test Suite Quick:
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: never
     # Run if "quick" test suite selected (and if previous jobs were successful)
-    - if: $TEST_SUITE == "quick"
+    - if: $TEST_SUITE == "quicktest"
   script:
     - ./run-docker.sh bash
     - pytest -m 'not (vivado or slow or vitis or board or notebooks or bnn_pynq)' --junitxml=$CI_PROJECT_DIR/reports/quick.xml --html=$CI_PROJECT_DIR/reports/quick.html --reruns 2 --forked --dist worksteal -n $CPU_CORES

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,13 +1,18 @@
 stages:
   - sync
   - singularity_build
+  - load_deps
   - test
 
 variables:
+  PIPELINE_NAME:
+    description: "Optional name to better identify this pipeline"
+    value: ""
   TEST_SUITE:
     description: "Select test suite to run"
     value: "full"
     options:
+      - "none"
       - "quicktest"
       - "main"
       - "rtlsim"
@@ -16,6 +21,9 @@ variables:
   CPU_CORES:
     description: "Select number of CPU cores and test workers"
     value: "8"
+  PARALLEL_JOBS:
+    description: "Number of parallel Slurm array jobs per Benchmark job"
+    value: "2"
   SLURM_TIMEOUT:
     description: "Select SLURM timeout"
     value: "3-0" # [days-hours]
@@ -25,10 +33,14 @@ variables:
   SLURM_QOS:
     description: "Optional QoS option (include --qos, e.g., --qos express)"
     value: ""
-  SINGULARITY_IMG_SELECT:
-    value: "finn_dev.sif"
+  MANUAL_CFG_PATH:
+    description: "Use this config file instead of configs stored in the repo. Path must be accessible to runner"
+    value: ""
+  FINN_XILINX_VERSION:
+    value: "2022.2"
 
 workflow:
+  name: '$PIPELINE_NAME'
   rules:
     # Run pipeline for GitHub PRs to dev (does not support PRs from forks)
     - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" && $CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME == "dev"
@@ -84,10 +96,44 @@ Singularity Image Build:
     - docker build --no-cache -f docker/Dockerfile.finn --tag=finn_docker_export .
     - apptainer build --force finn_singularity_image.sif docker-daemon://finn_docker_export:latest
     - rsync -vh finn_singularity_image.sif $PATH_SINGULARITY_IMG_BUILD/finn-plus/finn_$CI_COMMIT_REF_SLUG.sif
+    - echo SINGULARITY_IMG_SELECT=finn_$CI_COMMIT_REF_SLUG.sif > FINN_environment.env
   after_script: # Clean caches
     - echo 'y' | docker image prune
     - echo 'y' | docker builder prune
     - echo 'y' | apptainer cache clean
+  # Save env var selecting Singularity image to be used in subsequent jobs
+  artifacts:
+    reports:
+      dotenv: FINN_environment.env
+
+Fetch Repos:
+  id_tokens:
+    CI_JOB_JWT:
+      aud: https://git.uni-paderborn.de
+  stage: load_deps
+  tags:
+    - login
+  rules:
+    # Do not run on a schedule
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: never
+    # Otherwise run
+    - when: always
+  cache:
+    key: $CI_COMMIT_SHA
+    paths:
+      - deps
+  variables:
+    SINGULARITY_IMG_SELECT: "finn_dev.sif" # default, may be overwritten by dotenv artifact
+  script:
+    - ./fetch-repos.sh
+    # Workaround for https://gitlab.com/gitlab-org/gitlab/-/issues/349538
+    # Passing artifacts from optional parent jobs to child pipelines is not supported
+    # Therefore, we pass the dotenv artifact from "Singularity Image Build" through this job
+    - echo SINGULARITY_IMG_SELECT=$SINGULARITY_IMG_SELECT > FINN_environment_passthrough.env
+  artifacts:
+    reports:
+      dotenv: FINN_environment_passthrough.env
 
 FINN Test Suite 2022.2:
   id_tokens:
@@ -98,27 +144,25 @@ FINN Test Suite 2022.2:
     # Do not run on a schedule
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: never
-    # Select different Singularity image if it deviates from default (dev branch)
-    - changes:
-        paths:
-          - requirements.txt
-          - docker/Dockerfile.finn
-          - docker/finn_entrypoint.sh
-          - docker/quicktest.sh
-        compare_to: "dev"
-      variables:
-        SINGULARITY_IMG_SELECT: "finn_$CI_COMMIT_REF_SLUG.sif"
+    # Do not run if test suite has been deselected
+    - if: $TEST_SUITE == "none"
+      when: never
     # Always run, as long as there was no prior failure
     - when: on_success
+  cache:
+    key: $CI_COMMIT_SHA
+    policy: pull
+    paths:
+      - deps
   variables:
     SCHEDULER_PARAMETERS: "-A $PROJECT_ACCOUNT -p $SLURM_PARTITION -t $SLURM_TIMEOUT $SLURM_QOS --nodes 1 --ntasks 1 --cpus-per-task $CPU_CORES --exclusive"
     PYTEST_PARALLEL: "$CPU_CORES"
-    FINN_SINGULARITY: "$PATH_SINGULARITY_IMG/finn-plus/$SINGULARITY_IMG_SELECT"
     FINN_XILINX_VERSION: "2022.2"
   before_script:
     - cp -dfR .. $PATH_WORKDIR # Copy to working directory (e.g. RAMdisk)
     - cd $PATH_WORKDIR/finn-plus
     - module load system singularity
+    - export FINN_SINGULARITY=$PATH_SINGULARITY_IMG/finn-plus/$SINGULARITY_IMG_SELECT
   script:
     - ./run-docker.sh quicktest.sh $TEST_SUITE
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,9 +14,6 @@ variables:
     options:
       - "none"
       - "quicktest"
-      - "main"
-      - "rtlsim"
-      - "end2end"
       - "full"
   CPU_CORES:
     description: "Select number of CPU cores and test workers"
@@ -144,11 +141,8 @@ FINN Test Suite 2022.2:
     # Do not run on a schedule
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: never
-    # Do not run if test suite has been deselected
-    - if: $TEST_SUITE == "none"
-      when: never
-    # Always run, as long as there was no prior failure
-    - when: on_success
+    # Run if "full" test suite selected (and if previous jobs were successful)
+    - if: $TEST_SUITE == "full"
   cache:
     key: $CI_COMMIT_SHA
     policy: pull
@@ -156,7 +150,6 @@ FINN Test Suite 2022.2:
       - deps
   variables:
     SCHEDULER_PARAMETERS: "-A $PROJECT_ACCOUNT -p $SLURM_PARTITION -t $SLURM_TIMEOUT $SLURM_QOS --nodes 1 --ntasks 1 --cpus-per-task $CPU_CORES --exclusive"
-    PYTEST_PARALLEL: "$CPU_CORES"
     FINN_XILINX_VERSION: "2022.2"
   before_script:
     - cp -dfR .. $PATH_WORKDIR # Copy to working directory (e.g. RAMdisk)
@@ -164,7 +157,12 @@ FINN Test Suite 2022.2:
     - module load system singularity
     - export FINN_SINGULARITY=$PATH_SINGULARITY_IMG/finn-plus/$SINGULARITY_IMG_SELECT
   script:
-    - ./run-docker.sh quicktest.sh $TEST_SUITE
+    - ./run-docker.sh bash
+    - pytest -k 'not (rtlsim or end2end)' --junitxml=$CI_PROJECT_DIR/reports/main.xml --html=$CI_PROJECT_DIRreports/main.html --reruns 2 --forked --dist worksteal -n $CPU_CORES
+    - pytest -k 'rtlsim and not end2end' --junitxml=$CI_PROJECT_DIR/reports/rtlsim.xml --html=$CI_PROJECT_DIR/reports/rtlsim.html --reruns 2 --forked --dist worksteal -n $CPU_CORES
+    - pytest -k 'end2end' -m 'sanity_bnn or end2end or fpgadataflow or notebooks' --junitxml=$CI_PROJECT_DIR/reports/end2end.xml --html=$CI_PROJECT_DIR/reports/end2end.html --reruns 2 --forked --dist loadfile -n $CPU_CORES
+    - pytest_html_merger -i $CI_PROJECT_DIR/reports/ -o $CI_PROJECT_DIR/reports/full_test_suite.html
+    - exit
   artifacts:
     name: "test_reports"
     when: always
@@ -172,6 +170,19 @@ FINN Test Suite 2022.2:
       - reports/
     reports:
       junit: reports/*.xml
+
+FINN Test Suite Quick:
+  extends: FINN Test Suite 2022.2
+  rules:
+    # Do not run on a schedule
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: never
+    # Run if "quick" test suite selected (and if previous jobs were successful)
+    - if: $TEST_SUITE == "quick"
+  script:
+    - ./run-docker.sh bash
+    - pytest -m 'not (vivado or slow or vitis or board or notebooks or bnn_pynq)' --junitxml=$CI_PROJECT_DIR/reports/quick.xml --html=$CI_PROJECT_DIR/reports/quick.html --reruns 2 --forked --dist worksteal -n $CPU_CORES
+    - exit
 
 FINN Test Suite 2024.1:
   extends: FINN Test Suite 2022.2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,6 +126,8 @@ FINN Test Suite 2022.2:
     when: always
     paths:
       - reports/
+    reports:
+      junit: [reports/main.xml, reports/rtlsim.xml, reports/end2end.xml]
 
 FINN Test Suite 2024.1:
   extends: FINN Test Suite 2022.2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -171,7 +171,7 @@ FINN Test Suite 2022.2:
     paths:
       - reports/
     reports:
-      junit: [reports/main.xml, reports/rtlsim.xml, reports/end2end.xml]
+      junit: reports/*.xml
 
 FINN Test Suite 2024.1:
   extends: FINN Test Suite 2022.2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -160,6 +160,7 @@ FINN Test Suite 2022.2:
     - cd $PATH_WORKDIR/finn-plus
     - chmod 755 ./test.sh
     - module load system singularity
+    - ulimit -s unlimited # Increase stack size limit
     - export FINN_SINGULARITY=$PATH_SINGULARITY_IMG/finn-plus/$SINGULARITY_IMG_SELECT
   script:
     - ./run-docker.sh ./test.sh $TEST_SUITE

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -121,6 +121,11 @@ FINN Test Suite 2022.2:
     - module load system singularity
   script:
     - ./run-docker.sh quicktest.sh $TEST_SUITE
+  artifacts:
+    name: "test_reports"
+    when: always
+    paths:
+      - reports/
 
 FINN Test Suite 2024.1:
   extends: FINN Test Suite 2022.2

--- a/docker/Dockerfile.finn
+++ b/docker/Dockerfile.finn
@@ -103,9 +103,8 @@ RUN pip install ipykernel==6.21.2
 RUN pip install jupyter==1.0.0 --ignore-installed
 RUN pip install markupsafe==2.0.1
 RUN pip install matplotlib==3.7.0  --ignore-installed
-RUN pip install pytest-dependency==0.5.1
-RUN pip install pytest-xdist[setproctitle]==3.2.0
-RUN pip install pytest-parallel==0.1.1
+RUN pip install pytest-dependency==0.6.0
+RUN pip install pytest-xdist[setproctitle]==3.6.1
 RUN pip install "netron>=5.0.0"
 RUN pip install pandas==1.5.3
 RUN pip install scikit-learn==1.2.1
@@ -113,11 +112,13 @@ RUN pip install tqdm==4.64.1
 RUN pip install -e git+https://github.com/fbcotter/dataset_loading.git@0.0.4#egg=dataset_loading
 # these versions of pytest and associated plugins allow for stable collection of
 # test reports and code coverage reports in HTML
-RUN pip install pytest==6.2.5
-RUN pip install pytest-metadata==1.7.0
-RUN pip install pytest-html==3.0.0
-RUN pip install pytest-html-merger==0.0.8
-RUN pip install pytest-cov==4.1.0
+RUN pip install pytest==8.3.4
+RUN pip install pytest-metadata==3.1.1
+RUN pip install pytest-html==4.1.1
+RUN pip install pytest-html-merger==0.1.0
+RUN pip install pytest-cov==6.0.0
+RUN pip install pytest-forked==1.6.0
+RUN pip install pytest-rerunfailures==15.0
 RUN pip install pyyaml==6.0.1
 
 # extra dependencies from other FINN deps

--- a/docker/quicktest.sh
+++ b/docker/quicktest.sh
@@ -4,27 +4,23 @@
 
 cd $FINN_ROOT
 # check if command line argument is empty or not present
-if [ -z $1 ] || [ $1 = "quicktest" ]; then
+if [ -z $1 ]; then
   echo "Running quicktest: not (vivado or slow or board) with pytest-xdist"
-  pytest -m 'not (vivado or slow or vitis or board or notebooks or bnn_pynq)' --junitxml=reports/quick.xml --html=reports/quick.html --reruns 2 --forked --dist worksteal -n $PYTEST_PARALLEL
+  pytest -m 'not (vivado or slow or vitis or board or notebooks or bnn_pynq)' --dist=loadfile -n $PYTEST_PARALLEL
 elif [ $1 = "main" ]; then
   echo "Running main test suite: not (rtlsim or end2end) with pytest-xdist"
-  pytest -k 'not (rtlsim or end2end)' --junitxml=reports/main.xml --html=reports/main.html --reruns 2 --forked --dist worksteal -n $PYTEST_PARALLEL
+  pytest -k 'not (rtlsim or end2end)' --dist=loadfile -n $PYTEST_PARALLEL
 elif [ $1 = "rtlsim" ]; then
   echo "Running rtlsim test suite with pytest-xdist"
-# there are end2end tests which also have rtlsim in their name, but not vice versa
-  pytest -k 'rtlsim and not end2end' --junitxml=reports/rtlsim.xml --html=reports/rtlsim.html --reruns 2 --forked --dist worksteal -n $PYTEST_PARALLEL
+  pytest -k rtlsim --dist=loadfile -n $PYTEST_PARALLEL
 elif [ $1 = "end2end" ]; then
   echo "Running end2end test suite with no parallelism"
-# filtering by name "end2end" is not sufficient, as the bnn tests need to be selected by a marker
-  pytest -k end2end -m 'sanity_bnn or end2end or fpgadataflow or notebooks' --junitxml=reports/end2end.xml --html=reports/end2end.html --reruns 2 --forked --dist loadfile -n $PYTEST_PARALLEL
+  pytest -k end2end
 elif [ $1 = "full" ]; then
   echo "Running full test suite, each step with appropriate parallelism"
   $0 main;
   $0 rtlsim;
   $0 end2end;
-  echo "Merging individual HTML reports"
-  pytest_html_merger -i reports/ -o reports/full_test_suite.html
 else
-  echo "Unrecognized argument to quicktest.sh: $1"
+  echo "Unrecognized argument to quicktest.sh"
 fi

--- a/docker/quicktest.sh
+++ b/docker/quicktest.sh
@@ -6,18 +6,18 @@ cd $FINN_ROOT
 # check if command line argument is empty or not present
 if [ -z $1 ] || [ $1 = "quicktest" ]; then
   echo "Running quicktest: not (vivado or slow or board) with pytest-xdist"
-  pytest -m 'not (vivado or slow or vitis or board or notebooks or bnn_pynq)' --forked --dist loadfile -n $PYTEST_PARALLEL
+  pytest -m 'not (vivado or slow or vitis or board or notebooks or bnn_pynq)' --junitxml=reports/quick.xml --html=reports/quick.html --reruns 2 --forked --dist worksteal -n $PYTEST_PARALLEL
 elif [ $1 = "main" ]; then
   echo "Running main test suite: not (rtlsim or end2end) with pytest-xdist"
-  pytest -k 'not (rtlsim or end2end)' --junitxml=main.xml --html=reports/main.html --reruns 1 --forked --dist loadfile -n $PYTEST_PARALLEL
+  pytest -k 'not (rtlsim or end2end)' --junitxml=reports/main.xml --html=reports/main.html --reruns 2 --forked --dist worksteal -n $PYTEST_PARALLEL
 elif [ $1 = "rtlsim" ]; then
   echo "Running rtlsim test suite with pytest-xdist"
 # there are end2end tests which also have rtlsim in their name, but not vice versa
-  pytest -k 'rtlsim and not end2end' --junitxml=rtlsim.xml --html=reports/rtlsim.html --reruns 1 --forked --dist loadfile -n $PYTEST_PARALLEL
+  pytest -k 'rtlsim and not end2end' --junitxml=reports/rtlsim.xml --html=reports/rtlsim.html --reruns 2 --forked --dist worksteal -n $PYTEST_PARALLEL
 elif [ $1 = "end2end" ]; then
   echo "Running end2end test suite with no parallelism"
 # filtering by name "end2end" is not sufficient, as the bnn tests need to be selected by a marker
-  pytest -k end2end -m 'sanity_bnn or end2end or fpgadataflow or notebooks' --junitxml=end2end.xml --html=reports/end2end.html --reruns 1 --forked --dist loadfile -n $PYTEST_PARALLEL
+  pytest -k end2end -m 'sanity_bnn or end2end or fpgadataflow or notebooks' --junitxml=reports/end2end.xml --html=reports/end2end.html --reruns 2 --forked --dist loadfile -n $PYTEST_PARALLEL
 elif [ $1 = "full" ]; then
   echo "Running full test suite, each step with appropriate parallelism"
   $0 main;

--- a/docker/quicktest.sh
+++ b/docker/quicktest.sh
@@ -9,15 +9,15 @@ if [ -z $1 ] || [ $1 = "quicktest" ]; then
   pytest -m 'not (vivado or slow or vitis or board or notebooks or bnn_pynq)' --forked --dist loadfile -n $PYTEST_PARALLEL
 elif [ $1 = "main" ]; then
   echo "Running main test suite: not (rtlsim or end2end) with pytest-xdist"
-  pytest -k 'not (rtlsim or end2end)' --html=reports/main.html --reruns 1 --forked --dist loadfile -n $PYTEST_PARALLEL
+  pytest -k 'not (rtlsim or end2end)' --junitxml=main.xml --html=reports/main.html --reruns 1 --forked --dist loadfile -n $PYTEST_PARALLEL
 elif [ $1 = "rtlsim" ]; then
   echo "Running rtlsim test suite with pytest-xdist"
 # there are end2end tests which also have rtlsim in their name, but not vice versa
-  pytest -k 'rtlsim and not end2end' --html=reports/rtlsim.html --reruns 1 --forked --dist loadfile -n $PYTEST_PARALLEL
+  pytest -k 'rtlsim and not end2end' --junitxml=rtlsim.xml --html=reports/rtlsim.html --reruns 1 --forked --dist loadfile -n $PYTEST_PARALLEL
 elif [ $1 = "end2end" ]; then
   echo "Running end2end test suite with no parallelism"
 # filtering by name "end2end" is not sufficient, as the bnn tests need to be selected by a marker
-  pytest -k end2end -m 'sanity_bnn or end2end or fpgadataflow or notebooks' --html=reports/end2end.html --reruns 1 --forked --dist loadfile -n $PYTEST_PARALLEL
+  pytest -k end2end -m 'sanity_bnn or end2end or fpgadataflow or notebooks' --junitxml=end2end.xml --html=reports/end2end.html --reruns 1 --forked --dist loadfile -n $PYTEST_PARALLEL
 elif [ $1 = "full" ]; then
   echo "Running full test suite, each step with appropriate parallelism"
   $0 main;

--- a/docker/quicktest.sh
+++ b/docker/quicktest.sh
@@ -6,23 +6,25 @@ cd $FINN_ROOT
 # check if command line argument is empty or not present
 if [ -z $1 ] || [ $1 = "quicktest" ]; then
   echo "Running quicktest: not (vivado or slow or board) with pytest-xdist"
-  pytest -m 'not (vivado or slow or vitis or board or notebooks or bnn_pynq)' --forked --dist=loadfile -n $PYTEST_PARALLEL
+  pytest -m 'not (vivado or slow or vitis or board or notebooks or bnn_pynq)' --forked --dist loadfile -n $PYTEST_PARALLEL
 elif [ $1 = "main" ]; then
   echo "Running main test suite: not (rtlsim or end2end) with pytest-xdist"
-  pytest -k 'not (rtlsim or end2end)' --forked --dist=loadfile -n $PYTEST_PARALLEL
+  pytest -k 'not (rtlsim or end2end)' --html=reports/main.html --reruns 1 --forked --dist loadfile -n $PYTEST_PARALLEL
 elif [ $1 = "rtlsim" ]; then
-  echo "Running rtlsim test suite with pytest-parallel"
+  echo "Running rtlsim test suite with pytest-xdist"
 # there are end2end tests which also have rtlsim in their name, but not vice versa
-  pytest -k 'rtlsim and not end2end' --forked --workers $PYTEST_PARALLEL
+  pytest -k 'rtlsim and not end2end' --html=reports/rtlsim.html --reruns 1 --forked --dist loadfile -n $PYTEST_PARALLEL
 elif [ $1 = "end2end" ]; then
   echo "Running end2end test suite with no parallelism"
 # filtering by name "end2end" is not sufficient, as the bnn tests need to be selected by a marker
-  pytest -k end2end --forked -m 'sanity_bnn or end2end or fpgadataflow or notebooks'
+  pytest -k end2end -m 'sanity_bnn or end2end or fpgadataflow or notebooks' --html=reports/end2end.html --reruns 1 --forked --dist loadfile -n $PYTEST_PARALLEL
 elif [ $1 = "full" ]; then
   echo "Running full test suite, each step with appropriate parallelism"
   $0 main;
   $0 rtlsim;
   $0 end2end;
+  echo "Merging individual HTML reports"
+  pytest_html_merger -i reports/ -o reports/full_test_suite.html
 else
   echo "Unrecognized argument to quicktest.sh: $1"
 fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ pre-commit==3.3.2
 protobuf==3.20.3
 psutil==5.9.4
 pyscaffold==4.4
-pytest-forked==1.6.0
 scipy==1.10.1
 setupext-janitor>=1.1.2
 sigtools==4.0.1

--- a/src/finn/custom_op/fpgadataflow/hls/upsampler_hls.py
+++ b/src/finn/custom_op/fpgadataflow/hls/upsampler_hls.py
@@ -35,7 +35,7 @@ from finn.util.data_packing import npy_to_rtlsim_input, rtlsim_output_to_npy
 
 class UpsampleNearestNeighbour_hls(UpsampleNearestNeighbour, HLSBackend):
     """
-    Corresponds to finn-hlslib UpsampleNearestNeighbour_Batch function.
+    Corresponds to finn-hlslib UpsampleNearestNeighbour function.
     Upsampling is done with the Nearest Neighbour algorithm.
     The layer expects square feature maps for the in and output.
     """
@@ -78,7 +78,7 @@ class UpsampleNearestNeighbour_hls(UpsampleNearestNeighbour, HLSBackend):
         batch = self.get_nodeattr("numInputVectors")
         if is_2d:
             self.code_gen_dict["$DOCOMPUTE$"] = [
-                """UpsampleNearestNeighbour_Batch<OFMDim, IFMDim, IFMChannels,
+                """UpsampleNearestNeighbour<OFMDim, IFMDim, IFMChannels,
                 ap_uint<Input_precision> > (in0_%s, out_%s, numReps);"""
                 % (self.hls_sname(), self.hls_sname())
             ]

--- a/src/finn/util/basic.py
+++ b/src/finn/util/basic.py
@@ -33,7 +33,7 @@ import tempfile
 from qonnx.util.basic import roundup_to_integer_multiple
 
 # test boards
-test_board_map = ["Pynq-Z1", "KV260_SOM", "ZCU104", "U250"]
+test_board_map = ["Pynq-Z1", "KV260_SOM", "ZCU104", "U280"]
 
 # mapping from PYNQ board names to FPGA part names
 pynq_part_map = dict()

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+: ${PYTEST_PARALLEL=auto}
+: ${CI_PROJECT_DIR="."}
+
+cd $FINN_ROOT
+
+if [ -z $1 ] || [ $1 = "quicktest" ]; then
+  pytest -m 'not (vivado or slow or vitis or board or notebooks or bnn_pynq)' --junitxml=$CI_PROJECT_DIR/reports/quick.xml --html=$CI_PROJECT_DIR/reports/quick.html --reruns 2 --forked --dist worksteal -n $PYTEST_PARALLEL
+elif [ $1 = "full" ]; then
+  pytest -k 'not (rtlsim or end2end)' --junitxml=$CI_PROJECT_DIR/reports/main.xml --html=$CI_PROJECT_DIRreports/main.html --reruns 2 --forked --dist worksteal -n $PYTEST_PARALLEL
+  pytest -k 'rtlsim and not end2end' --junitxml=$CI_PROJECT_DIR/reports/rtlsim.xml --html=$CI_PROJECT_DIR/reports/rtlsim.html --reruns 2 --forked --dist worksteal -n $PYTEST_PARALLEL
+  pytest -k 'end2end' -m 'sanity_bnn or end2end or fpgadataflow or notebooks' --junitxml=$CI_PROJECT_DIR/reports/end2end.xml --html=$CI_PROJECT_DIR/reports/end2end.html --reruns 2 --forked --dist loadfile -n $PYTEST_PARALLEL
+  pytest_html_merger -i $CI_PROJECT_DIR/reports/ -o $CI_PROJECT_DIR/reports/full_test_suite.html
+else
+  echo "Unrecognized argument to test.sh: $1"
+fi

--- a/test.sh
+++ b/test.sh
@@ -6,11 +6,11 @@
 cd $FINN_ROOT
 
 if [ -z $1 ] || [ $1 = "quicktest" ]; then
-  pytest -m 'not (vivado or slow or vitis or board or notebooks or bnn_pynq)' --junitxml=$CI_PROJECT_DIR/reports/quick.xml --html=$CI_PROJECT_DIR/reports/quick.html --reruns 2 --forked --dist worksteal -n $PYTEST_PARALLEL
+  pytest -m 'not (vivado or slow or vitis or board or notebooks or bnn_pynq)' --junitxml=$CI_PROJECT_DIR/reports/quick.xml --html=$CI_PROJECT_DIR/reports/quick.html --reruns 1 --dist worksteal -n $PYTEST_PARALLEL
 elif [ $1 = "full" ]; then
-  pytest -k 'not (rtlsim or end2end)' --junitxml=$CI_PROJECT_DIR/reports/main.xml --html=$CI_PROJECT_DIRreports/main.html --reruns 2 --forked --dist worksteal -n $PYTEST_PARALLEL
-  pytest -k 'rtlsim and not end2end' --junitxml=$CI_PROJECT_DIR/reports/rtlsim.xml --html=$CI_PROJECT_DIR/reports/rtlsim.html --reruns 2 --forked --dist worksteal -n $PYTEST_PARALLEL
-  pytest -k 'end2end' -m 'sanity_bnn or end2end or fpgadataflow or notebooks' --junitxml=$CI_PROJECT_DIR/reports/end2end.xml --html=$CI_PROJECT_DIR/reports/end2end.html --reruns 2 --forked --dist loadfile -n $PYTEST_PARALLEL
+  pytest -k 'not (rtlsim or end2end)' --junitxml=$CI_PROJECT_DIR/reports/main.xml --html=$CI_PROJECT_DIRreports/main.html --reruns 1 --dist worksteal -n $PYTEST_PARALLEL
+  pytest -k 'rtlsim and not end2end' --junitxml=$CI_PROJECT_DIR/reports/rtlsim.xml --html=$CI_PROJECT_DIR/reports/rtlsim.html --reruns 1 --dist worksteal -n $PYTEST_PARALLEL
+  pytest -k 'end2end' -m 'sanity_bnn or end2end or fpgadataflow or notebooks' --junitxml=$CI_PROJECT_DIR/reports/end2end.xml --html=$CI_PROJECT_DIR/reports/end2end.html --reruns 1 --dist loadfile -n $PYTEST_PARALLEL
   pytest_html_merger -i $CI_PROJECT_DIR/reports/ -o $CI_PROJECT_DIR/reports/full_test_suite.html
 else
   echo "Unrecognized argument to test.sh: $1"

--- a/tests/fpgadataflow/test_fpgadataflow_ipstitch.py
+++ b/tests/fpgadataflow/test_fpgadataflow_ipstitch.py
@@ -322,7 +322,7 @@ def test_fpgadataflow_ipstitch_iodma_floorplan():
 
 
 # board
-@pytest.mark.parametrize("board", ["U250"])
+@pytest.mark.parametrize("board", ["U280"])
 # clock period
 @pytest.mark.parametrize("period_ns", [5])
 # override mem_mode to external


### PR DESCRIPTION
Update pytest and plugins.

Log HTML and Junit.

Improve test parallelization.

Rerun failed tests.

Load dependencies in separate job.

Try to increase stack size instead of running tests with --forked.

Try to fix last remaining failing tests (upsampler and Alveo end2end).