### PR TITLE
[Fix] Provide HLS estimates as ints

### DIFF
--- a/src/finn/analysis/fpgadataflow/hls_synth_res_estimation.py
+++ b/src/finn/analysis/fpgadataflow/hls_synth_res_estimation.py
@@ -70,7 +70,8 @@ def hls_synth_res_estimation(model):
                     root = tree.getroot()
                     for item in root.findall("AreaEstimates/Resources"):
                         for child in item:
-                            res_dict[node.name][child.tag] = child.text
+                            if child.text is not None:
+                                res_dict[node.name][child.tag] = int(child.text)
                 else:
                     warnings.warn(
                         """Could not find report files, values will be set to zero


### PR DESCRIPTION
HLS Synth estimates are read from the projects XML file without automatically converting the read contents. They are now being parsed as ints. If a field doesn't exist, it stays at the pre-set value 0.