### PR TITLE
Minor fixes to build command, preparations for initial release

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,10 @@
+Copyright for portions of project FINN+ is held by AMD as part of project FINN
+and is provided under the BSD license. All other copyright for project FINN+
+is held by Paderborn University and is provided under the same license.
+
 Copyright (C) 2020-2022, Xilinx, Inc.
-Copyright (C) 2022-2024, Advanced Micro Devices, Inc.
+Copyright (C) 2022-2025, Advanced Micro Devices, Inc.
+Copyright (C) 2025, Paderborn University
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -12,7 +17,7 @@ modification, are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* Neither the name of FINN nor the names of its
+* Neither the name of FINN/FINN+ nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission.
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 # Dataflow Compiler for Fast, Scalable Quantized Neural Network Inference on FPGAs
 
-**FINN+** is a fork of **FINN**, an experimental framework from Integrated Communications and AI Lab of AMD Research & Advanced Development to explore deep neural network inference on FPGAs.
+**FINN+** is a fork of **FINN**, an experimental framework from the Integrated Communications and AI Lab of AMD Research & Advanced Development to explore deep neural network inference on FPGAs.
 It specifically targets quantized neural networks, with emphasis on generating dataflow-style architectures customized for each network.
 The resulting FPGA accelerators are highly efficient and can yield high throughput and low latency.
 The framework is fully open-source in order to give a higher degree of flexibility, and is intended to enable neural network research spanning several layers of the software/hardware abstraction stack.
 
 **To get an overview of how FINN+ is used, take a look at the Getting Started section below!**
 
-**For the time being, we refer to the original project [webpage](https://xilinx.github.io/finn/) for further information and documentation.**
+**While our [Wiki](https://github.com/eki-project/finn-plus/wiki) is under construction, we refer to the original [FINN homepage](https://xilinx.github.io/finn/) for further information.**
 
 ## FINN+ Extensions
 **FINN+** aims to incorporate all development from the upstream repository (dev branch) while extending **FINN** in all directions, including the following list of features that are either in progress or already completed:
@@ -32,27 +32,36 @@ Please refer to our [**Feature Tracker**](https://github.com/orgs/eki-project/pr
 While some items are already on-track to be merged into the upstream repository, we try to merge them into the **FINN+** dev branch as early as possible to increase development pace and drive our research forward.
 
 ## Getting Started
-This is a very quick overview of how to get started, for additional information please refer to our [**wiki**](https://github.com/eki-project/finn-plus/wiki)!
+This is a quick overview of how to get started, for additional information please refer to our [**Wiki**](https://github.com/eki-project/finn-plus/wiki)!
 
 ### Requirements
 The primary dependencies currently are:
-- Python >= 3.10 (<= 3.12)
-- Poetry >= 2.0
-- Vivado, Vitis, Vitis HLS (preferably 2022.2 or 2024.2)
-- Some basic system-level packages, refer to the "installDependencies.sh" script
+- Python >= 3.10 (< 3.12)
+- Vivado, Vitis, Vitis HLS (2022.2 or 2024.2)
+- Some basic system-level packages, refer to the [**dependency installation script**](https://github.com/eki-project/finn-plus/blob/main/installDependencies.sh)
 
-### Running a FINN build Flow
-To get started, clone this repository anywhere you like. To start your first FINN build continue like this:
+### Installing via pip
+After preparing the dependencies mentioned above, simply run the following to start a build flow:
+```
+# Make sure to create a fresh virtual environment for FINN+
+pip install finn-plus          # Install FINN+ and its Python dependencies via pip
+finn deps update               # Ensure FINN+ pulled all further dependencies (this might update packages in your venv!)
+finn build build_config.yaml   # Run a FINN+ build defined in a YAML file
+```
+
+### Installing from the repository
+To install directly from the repository, you'll need Poetry (>= 2.0) for dependency management. After cloning the repo and setting up the system-level dependencies, run the following to start a build flow:
 ```
 cd finn-plus
-poetry install                # Install Python packages into a Poetry-managed virtual environment
-source <your-poetry-venv>     # Use "poetry env info" to find the path to your poetry venv. For further information visit the poetry documentation
-finn config create            # Create a default configuration in ~/.finn/settings.yaml. Optional but recommended
-finn run some/path/build.py   # Run a FINN build defined in a Python script
+poetry install                 # Install Python packages into a Poetry-managed virtual environment
+source <your-poetry-venv>      # Use "poetry env info" to find the path to your Poetry venv. For further information visit the Poetry documentation
+finn config create             # Create a default configuration in ~/.finn/settings.yaml. Optional but recommended
+finn deps update               # Ensure FINN+ pulled all further dependencies (this might update packages in your venv!)
+finn build build_config.yaml   # Run a FINN+ build defined in a YAML file
 ```
 
 ## About Us
-This repository is maintained by researchers from the [Computer Engineering Group](https://en.cs.uni-paderborn.de/ceg) (CEG) and [Paderborn Center for Parallel Computing](https://pc2.uni-paderborn.de/) (PC²) at Paderborn University, Germany as part of the [eki research project](https://www.eki-project.tech/).
+FINN+ is maintained by researchers from the [Computer Engineering Group](https://en.cs.uni-paderborn.de/ceg) (CEG) and [Paderborn Center for Parallel Computing](https://pc2.uni-paderborn.de/) (PC²) at Paderborn University, Germany as part of the [eki research project](https://www.eki-project.tech/).
 
 <p align="left">
 <a href="https://en.cs.uni-paderborn.de/ceg"><img align="top" src="https://cs.uni-paderborn.de/fileadmin-eim/informatik/fg/ce/MiscImages/UPB_Logo_ENG_coloured_RGB.jpg" alt="logo" style="margin-right: 20px" width="250"/></a>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
 name = "finn-plus"
+description = "Fork of FINN, a QNN dataflow compiler for AMD/Xilinx FPGAs"
 dynamic = ["version"]
 maintainers = [
   {name = "Felix Jentzsch", email = "felix.jentzsch@upb.de"},
@@ -8,6 +9,10 @@ maintainers = [
   {name = "Bjarne Wintermann", email = "bjarne.wintermann@upb.de"}
 ]
 readme = "README.md"
+
+[project.urls]
+"GitHub" = "https://github.com/eki-project/finn-plus"
+"EKI Project" = "https://www.eki-project.tech/"
 
 [tool.poetry]
 packages = [

--- a/src/finn/interface/run_finn.py
+++ b/src/finn/interface/run_finn.py
@@ -211,11 +211,21 @@ def build(
     if dfbc is None:
         error("Failed to generate dataflow build config!")
         sys.exit(1)
+
+    # Set start and stop steps
     if dfbc.start_step is None and start != "":
         dfbc.start_step = start
     if dfbc.stop_step is None and stop != "":
         dfbc.stop_step = stop
+
+    # Set output directory to where the config lies, not where FINN lies
+    if not Path(dfbc.output_dir).is_absolute():
+        dfbc.output_dir = str((config_path.parent / dfbc.output_dir).absolute())
     status(f"Output directory is {dfbc.output_dir}")
+
+    # Add path of config to sys.path so that custom steps can be found
+    sys.path.append(str(config_path.parent.absolute()))
+
     Console().rule(
         f"[bold cyan]Running FINN with config[/bold cyan][bold orange1] "
         f"{config_path.name}[/bold orange1][bold cyan] on model [/bold cyan]"


### PR DESCRIPTION
PR to collect some last changes to be made before a main release.
So far:
- Fixed `output_dir` location. If the path given is relative, it is searched from the location of the `config.yaml`, as expected
- Fixed a bug, where custom steps could not be imported since the module couldn't be found in `PYTHONPATH` / `sys.path`