### PR TITLE
[Lint] Add Ruff Configuration to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,3 +138,17 @@ profile="black"
 ignore_comments=true
 ignore_whitespace=true
 honor_noqa=true
+
+
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint.per-file-ignores]
+"src/**.py" = [
+    "RET504",   # Assign to var before return
+    "PERF401",  # Replace for-loop with list comprehension
+    "SIM118",   # Using "a in b" instead of "a in b.keys()"
+    "UP015",    # open("file.txt", "r") -> open("file.txt")
+    "ANN401",   # Don't use the "Any" type
+    "I001"      # Unsorted imports (done by pre-commit)
+]


### PR DESCRIPTION
Add FINN specific settings for using Ruff as a linter. Added some ignores for patterns that often occur in FINN (often for readability reasons). Ignored rules have their meaning in comments behind the rule ID. Line-length mirrors the isort value.
Probably more config to be done, going to make this draft at first.  