### PR TITLE
Add custom exception handling to builder

### DIFF
--- a/src/finn/builder/build_dataflow.py
+++ b/src/finn/builder/build_dataflow.py
@@ -43,6 +43,7 @@ from rich.logging import RichHandler
 
 from finn.builder.build_dataflow_config import DataflowBuildConfig, default_build_dataflow_steps
 from finn.builder.build_dataflow_steps import build_dataflow_step_lookup
+from finn.util.exception import UserException
 
 
 # adapted from https://stackoverflow.com/a/39215961
@@ -140,10 +141,13 @@ def resolve_build_steps(cfg: DataflowBuildConfig, partial: bool = True) -> list[
 
 def resolve_step_filename(step_name: str, cfg: DataflowBuildConfig, step_delta: int = 0):
     step_names = list(map(lambda x: x.__name__, resolve_build_steps(cfg, partial=False)))
-    assert step_name in step_names, "start_step %s not found" + step_name
+    if step_name not in step_names:
+        raise UserException(
+            f"Cannot restart from step {step_name}.Step {step_name} for restarting not found."
+        )
     step_no = step_names.index(step_name) + step_delta
-    assert step_no >= 0, "Invalid step+delta combination"
-    assert step_no < len(step_names), "Invalid step+delta combination"
+    if step_no < 0 or step_no >= len(step_names):
+        raise RuntimeError("Invalid step+delta combination")
     filename = cfg.output_dir + "/intermediate_models/"
     filename += "%s.onnx" % (step_names[step_no])
     return filename
@@ -155,19 +159,6 @@ def build_dataflow_cfg(model_filename, cfg: DataflowBuildConfig):
     :param model_filename: ONNX model filename to build
     :param cfg: Build configuration
     """
-    # if start_step is specified, override the input model
-    if cfg.start_step is None:
-        print(f"Building dataflow accelerator from {model_filename}")
-        model = ModelWrapper(model_filename)
-    else:
-        intermediate_model_filename = resolve_step_filename(cfg.start_step, cfg, -1)
-        out = (
-            f"Building dataflow accelerator from intermediate"
-            f" checkpoint {intermediate_model_filename}"
-        )
-        print(out)
-        model = ModelWrapper(intermediate_model_filename)
-    assert type(model) is ModelWrapper
     finn_build_dir = os.environ["FINN_BUILD_DIR"]
 
     print(f"Intermediate outputs will be generated in {finn_build_dir}")
@@ -205,27 +196,42 @@ def build_dataflow_cfg(model_filename, cfg: DataflowBuildConfig):
 
     if cfg.console_log_level != "NONE":
         # set up console logger
-        console = RichHandler(show_time=True, show_path=False, console=console)
+        consoleHandler = RichHandler(show_time=True, show_path=False, console=console)
 
         if cfg.console_log_level == "DEBUG":
-            console.setLevel(logging.DEBUG)
+            consoleHandler.setLevel(logging.DEBUG)
         elif cfg.console_log_level == "INFO":
-            console.setLevel(logging.INFO)
+            consoleHandler.setLevel(logging.INFO)
         elif cfg.console_log_level == "WARNING":
-            console.setLevel(logging.WARNING)
+            consoleHandler.setLevel(logging.WARNING)
         elif cfg.console_log_level == "ERROR":
-            console.setLevel(logging.ERROR)
+            consoleHandler.setLevel(logging.ERROR)
         elif cfg.console_log_level == "CRITICAL":
-            console.setLevel(logging.CRITICAL)
-        logging.getLogger().addHandler(console)
+            consoleHandler.setLevel(logging.CRITICAL)
+        logging.getLogger().addHandler(consoleHandler)
 
-    # start processing
-    step_num = 1
-    time_per_step = dict()
-    build_dataflow_steps = resolve_build_steps(cfg)
+    # Setup done, start processing
+    try:
+        # if start_step is specified, override the input model
+        if cfg.start_step is None:
+            print(f"Building dataflow accelerator from {model_filename}")
+            model = ModelWrapper(model_filename)
+        else:
+            intermediate_model_filename = resolve_step_filename(cfg.start_step, cfg, -1)
+            out = (
+                f"Building dataflow accelerator from intermediate"
+                f" checkpoint {intermediate_model_filename}"
+            )
+            print(out)
+            model = ModelWrapper(intermediate_model_filename)
+        assert type(model) is ModelWrapper
 
-    for transform_step in build_dataflow_steps:
-        try:
+        # start processing
+        step_num = 1
+        time_per_step = dict()
+        build_dataflow_steps = resolve_build_steps(cfg)
+
+        for transform_step in build_dataflow_steps:
             step_name = transform_step.__name__
             print(f"Running step: {step_name} [{step_num}/{len(build_dataflow_steps)}]")
 
@@ -241,17 +247,21 @@ def build_dataflow_cfg(model_filename, cfg: DataflowBuildConfig):
                     os.makedirs(intermediate_model_dir)
                 model.save(os.path.join(intermediate_model_dir, chkpt_name))
             step_num += 1
-        except:  # noqa
-            # print exception info and traceback
-            extype, value, tb = sys.exc_info()
-            console.print_exception(show_locals=False)
-            # start postmortem debug if configured
-            if cfg.enable_build_pdb_debug:
-                pdb.post_mortem(tb)
-            else:
-                print("enable_build_pdb_debug not set in build config, exiting...")
-            print("Build failed")
-            return -1
+    except UserException as ue:
+        console.print(f"[red]Error: {str(ue)}")
+        print("Build failed")
+        return -1
+    except:  # noqa
+        # print exception info and traceback
+        extype, value, tb = sys.exc_info()
+        console.print_exception(show_locals=False)
+        # start postmortem debug if configured
+        if cfg.enable_build_pdb_debug:
+            pdb.post_mortem(tb)
+        else:
+            print("enable_build_pdb_debug not set in build config, exiting...")
+        print("Build failed")
+        return -1
 
     with open(os.path.join(cfg.output_dir, "time_per_step.json"), "w") as f:
         json.dump(time_per_step, f, indent=2)

--- a/src/finn/builder/build_dataflow.py
+++ b/src/finn/builder/build_dataflow.py
@@ -251,9 +251,14 @@ def build_dataflow_cfg(model_filename, cfg: DataflowBuildConfig):
         console.print(f"[red]Error: {str(ue)}")
         print("Build failed")
         return -1
+    except KeyboardInterrupt:
+        console.print("[red]Aborting...")
+        print("Build failed")
+        return -1
     except:  # noqa
         # print exception info and traceback
         extype, value, tb = sys.exc_info()
+        console.print("[red]Internal Compiler Error:")
         console.print_exception(show_locals=False)
         # start postmortem debug if configured
         if cfg.enable_build_pdb_debug:

--- a/src/finn/builder/build_dataflow.py
+++ b/src/finn/builder/build_dataflow.py
@@ -223,6 +223,14 @@ def build_dataflow_cfg(model_filename, cfg: DataflowBuildConfig):
             print(f"Building dataflow accelerator from {model_filename}")
             model = ModelWrapper(model_filename)
         else:
+            if model_filename != "":
+                log.warning(
+                    "When using a start-step, FINN automatically searches "
+                    "for the correct model to use from previous runs, overwriting your "
+                    "passed model file (but still using it's path for the location of the "
+                    "temporary file directory, etc.). This behaviour might change "
+                    "in future versions!"
+                )
             intermediate_model_filename = resolve_step_filename(cfg.start_step, cfg, -1)
             out = (
                 f"Building dataflow accelerator from intermediate"

--- a/src/finn/builder/build_dataflow.py
+++ b/src/finn/builder/build_dataflow.py
@@ -275,10 +275,10 @@ def build_dataflow_cfg(model_filename, cfg: DataflowBuildConfig):
         extype, value, tb = sys.exc_info()
         if print_full_traceback:
             # print exception info and traceback
-            log.error("Internal compiler error:")
+            log.error("FINN Internal compiler error:")
             console.print_exception(show_locals=False)
         else:
-            console.print(f"[bold red]FINN User Error: [/bold red]{e}")
+            console.print(f"[bold red]FINN Error: [/bold red]{e}")
             log.error(f"{e}")
             print("Build failed")
             return -1  # A user error shouldn't be need to be fixed using PDB
@@ -286,8 +286,6 @@ def build_dataflow_cfg(model_filename, cfg: DataflowBuildConfig):
         # start postmortem debug if configured
         if cfg.enable_build_pdb_debug:
             pdb.post_mortem(tb)
-        else:
-            print("enable_build_pdb_debug not set in build config, exiting...")
         print("Build failed")
         return -1
 

--- a/src/finn/builder/build_dataflow_config.py
+++ b/src/finn/builder/build_dataflow_config.py
@@ -341,7 +341,7 @@ class DataflowBuildConfig(DataClassJSONMixin, DataClassYAMLMixin):
     enable_hw_debug: Optional[bool] = False
 
     #: Whether pdb postmortem debuggig will be launched when the build fails
-    enable_build_pdb_debug: Optional[bool] = True
+    enable_build_pdb_debug: Optional[bool] = False
 
     #: When True, additional verbose information will be written to the log file.
     #: Otherwise, these additional information will be suppressed.

--- a/src/finn/util/exception.py
+++ b/src/finn/util/exception.py
@@ -1,5 +1,20 @@
-class UserException(Exception):
+class FINNError(Exception):
+    """Base-class for FINN exceptions. Useful to differentiate exceptions while catching."""
+
+    def __init__(self, *args: object) -> None:
+        super().__init__(*args)
+
+
+class UserError(FINNError):
     """Custom exception class which should be used to
     print errors without stacktraces if debug is disabled."""
 
-    pass
+    def __init__(self, *args: object) -> None:
+        super().__init__(*args)
+
+
+class FINNConfigurationError(FINNError):
+    """Error emitted when FINN is configured incorrectly"""
+
+    def __init__(self, *args: object) -> None:
+        super().__init__(*args)

--- a/src/finn/util/exception.py
+++ b/src/finn/util/exception.py
@@ -1,3 +1,12 @@
+"""
+FINNError is the base class for all errors.
+FINNUserError is a purely user-facing error that has nothing to do with FINNs internals
+FINNInternalError is a compiler internal error
+
+Every error should subclass FINNUserError or FINNInternalError
+"""
+
+
 class FINNError(Exception):
     """Base-class for FINN exceptions. Useful to differentiate exceptions while catching."""
 
@@ -5,7 +14,14 @@ class FINNError(Exception):
         super().__init__(*args)
 
 
-class UserError(FINNError):
+class FINNInternalError(FINNError):
+    """Custom exception class for internal compiler errors"""
+
+    def __init__(self, *args: object) -> None:
+        super().__init__(*args)
+
+
+class FINNUserError(FINNError):
     """Custom exception class which should be used to
     print errors without stacktraces if debug is disabled."""
 
@@ -13,8 +29,15 @@ class UserError(FINNError):
         super().__init__(*args)
 
 
-class FINNConfigurationError(FINNError):
+class FINNConfigurationError(FINNUserError):
     """Error emitted when FINN is configured incorrectly"""
+
+    def __init__(self, *args: object) -> None:
+        super().__init__(*args)
+
+
+class FINNDataflowError(FINNInternalError):
+    """Errors regarding the dataflow, dataflow config, step resolution, etc."""
 
     def __init__(self, *args: object) -> None:
         super().__init__(*args)

--- a/src/finn/util/exception.py
+++ b/src/finn/util/exception.py
@@ -1,0 +1,5 @@
+class UserException(Exception):
+    """Custom exception class which should be used to
+    print errors without stacktraces if debug is disabled."""
+
+    pass


### PR DESCRIPTION
This PR adds a custom user exception class, which does not print a stacktrace. Refactored build_dataflow to cover all critical parts of FINN in try block.