### PR TITLE
FIFO gauge mode for simulation depth monitoring

### DIFF
--- a/finn-rtllib/fifo/hdl/fifo_gauge.sv
+++ b/finn-rtllib/fifo/hdl/fifo_gauge.sv
@@ -27,62 +27,72 @@
  * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @brief	Queue-based unbounded FIFO drop-in for size-gauging simulation.
+ * @author	Thomas B. Preußer <thomas.preusser@amd.com>
  *****************************************************************************/
 
-module $TOP_MODULE_NAME$(
-//- Global Control ------------------
-(* X_INTERFACE_PARAMETER = "ASSOCIATED_BUSIF in0_V:out0_V, ASSOCIATED_RESET = ap_rst_n" *)
-(* X_INTERFACE_INFO = "xilinx.com:signal:clock:1.0 ap_clk CLK" *)
-input   ap_clk,
-(* X_INTERFACE_PARAMETER = "POLARITY ACTIVE_LOW" *)
-input   ap_rst_n,
+module fifo_gauge #(
+	int unsigned  WIDTH,
+	int unsigned  COUNT_WIDTH = 32
+)(
+	input	logic  clk,
+	input	logic  rst,
 
-output $COUNT_RANGE$ count,
-output $COUNT_RANGE$ maxcount,
+	input	logic [WIDTH-1:0]  idat,
+	input	logic  ivld,
+	output	logic  irdy,
 
-//- AXI Stream - Input --------------
-output   in0_V_TREADY,
-input   in0_V_TVALID,
-input  $IN_RANGE$ in0_V_TDATA,
+	output	logic [WIDTH-1:0]  odat,
+	output	logic  ovld,
+	input	logic  ordy,
 
-//- AXI Stream - Output --------------
-input   out0_V_TREADY,
-output   out0_V_TVALID,
-output  $OUT_RANGE$ out0_V_TDATA
+	output	logic [COUNT_WIDTH-1:0]  count,
+	output	logic [COUNT_WIDTH-1:0]  maxcount
 );
 
-	localparam fifo_core = "$FIFO_CORE$";
+	// The internal Queue serving as data buffer and an output register
+	logic [WIDTH-1:0]  Q[$] = {};
+	logic [COUNT_WIDTH-1:0]  Count    = 0;
+	logic [COUNT_WIDTH-1:0]  MaxCount = 0;
 
-	case(fifo_core)
-	"sim_fifo_gauge":
-		fifo_gauge #(.WIDTH($WIDTH$), .COUNT_WIDTH($COUNT_WIDTH$)) fifo (
-			.clk(ap_clk), .rst(!ap_rst_n),
-			.idat(in0_V_TDATA), .ivld(in0_V_TVALID), .irdy(in0_V_TREADY),
-			.odat(out0_V_TDATA), .ovld(out0_V_TVALID), .ordy(out0_V_TREADY),
-			.count(count), .maxcount(maxcount)
-		);
-	"q_srl":
-		Q_srl #(
-		.depth($DEPTH$),
-		.width($WIDTH$)
-		)
-		impl
-		(
-		.clock(ap_clk),
-		.reset(!ap_rst_n),
-		.count(count),
-		.maxcount(maxcount),
-		.i_d(in0_V_TDATA),
-		.i_v(in0_V_TVALID),
-		.i_r(in0_V_TREADY),
-		.o_d(out0_V_TDATA),
-		.o_v(out0_V_TVALID),
-		.o_r(out0_V_TREADY)
-		);
-	default: initial begin
-			$error("Unrecognized FIFO_CORE '%s'", FIFO_CORE);
-			$finish;
+	logic  OVld = 0;
+	logic [WIDTH-1:0]  ODat = 'x;
+
+	always_ff @(posedge clk) begin
+		if(rst) begin
+			Q        <= {};
+			Count    <= 0;
+			MaxCount <= 0;
+			OVld <= 0;
+			ODat <= 'x;
 		end
-		endcase
+		else begin
+			// Always take input
+			if(ivld)  Q.push_back(idat);
 
-endmodule
+			// Take Count
+			Count <= Q.size;
+			if(Q.size > MaxCount)  MaxCount <= Q.size;
+
+			// Offer output when available
+			if(!OVld || ordy) begin
+				if(Q.size == 0) begin
+					OVld <= 0;
+					ODat <= 'x;
+				end
+				else begin
+					OVld <= 1;
+					ODat <= Q.pop_front();
+				end
+			end
+		end
+	end
+	assign	irdy = 1;
+	assign	ovld = OVld;
+	assign	odat = ODat;
+
+	assign	count = Count;
+	assign	maxcount = MaxCount;
+
+endmodule : fifo_gauge

--- a/finn-rtllib/fifo/hdl/fifo_gauge_tb.sv
+++ b/finn-rtllib/fifo/hdl/fifo_gauge_tb.sv
@@ -1,0 +1,117 @@
+/******************************************************************************
+ *  Copyright (c) 2021, Xilinx, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2.  Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *
+ *  3.  Neither the name of the copyright holder nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION). HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ *  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @brief	Testbench for fifo_gauge.
+ * @author	Thomas B. Preußer <thomas.preusser@amd.com>
+ *******************************************************************************/
+module fifo_gauge_tb;
+
+	localparam int unsigned  N = 1500;
+	localparam int unsigned  W = 20;
+	typedef logic [W-1:0]  data_t;
+	typedef logic [ 31:0]  count_t;
+
+	// Global Control
+	logic  clk = 0;
+	always #5ns  clk = !clk;
+	uwire  rst = 0;
+
+	//-----------------------------------------------------------------------
+	// DUT
+
+	// Input Stream
+	data_t  idat;
+	logic   ivld;
+	uwire   irdy;
+
+	// Output Stream
+	uwire data_t  odat;
+	uwire         ovld;
+	logic         ordy;
+
+	// Depth Monitoring
+	uwire count_t  maxcount;
+
+	fifo_gauge #(.WIDTH(W)) dut (
+		.clk, .rst,
+		.idat, .ivld, .irdy,
+		.odat, .ovld, .ordy,
+		.count(), .maxcount
+	);
+
+	//-----------------------------------------------------------------------
+	// Stimulus
+	data_t  Q[$] = {};
+	initial begin
+		idat = 'x;
+		ivld =  0;
+		@(posedge clk iff !rst);
+		repeat(N) begin
+			automatic data_t  data = $urandom();
+			repeat(3-$clog2(2+$urandom()%6))  @(posedge clk);
+			idat <= data;
+			ivld <= 1;
+			Q.push_back(data);
+			@(posedge clk);
+			idat <= 'x;
+			ivld <=  0;
+		end
+	end
+
+	//-----------------------------------------------------------------------
+	// Checker
+	initial begin
+		automatic bit  good = 1;
+
+		ordy = 0;
+		@(posedge clk iff !rst);
+		repeat(N) begin
+			repeat(3-$clog2(2+$urandom()%6))  @(posedge clk);
+			ordy <= 1;
+			@(posedge clk iff ovld);
+			assert(Q.size()) else begin
+				good = 0;
+				$error("Spurious output.");
+				$stop;
+			end
+			assert(odat == Q.pop_front()) else begin
+				good = 0;
+				$error("Output mismatch.");
+				$stop;
+			end
+			ordy <= 0;
+		end
+
+		$display("Test %s.", good? "completed SUCCESSfully" : "FAILed");
+		$display("MAX DEPTH: %0d", maxcount);
+		$finish;
+	end
+
+endmodule : fifo_gauge_tb

--- a/src/finn/custom_op/fpgadataflow/rtl/streamingfifo_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/streamingfifo_rtl.py
@@ -75,6 +75,14 @@ class StreamingFIFO_rtl(StreamingFIFO, RTLBackend):
             ret["ap_none"] = ["maxcount"]
         return ret
 
+    def is_sim_fifo_gauge(self):
+        # special case: a StreamingFIFO layer with impl_style=rtl
+        # depth_monitor=1 is implemented using a Verilog infite
+        # queue sim instead of Q_srl
+        is_rtl = self.get_nodeattr("impl_style") == "rtl"
+        is_depth_monitor = self.get_nodeattr("depth_monitor") == 1
+        return is_depth_monitor and is_rtl
+
     def generate_hdl(self, model, fpgapart, clk):
         rtlsrc = os.path.join(os.environ["FINN_RTLLIB"], "fifo/hdl")
         template_path = rtlsrc + "/fifo_template.v"
@@ -88,12 +96,22 @@ class StreamingFIFO_rtl(StreamingFIFO, RTLBackend):
         code_gen_dict["$TOP_MODULE_NAME$"] = topname
         # make instream width a multiple of 8 for axi interface
         in_width = self.get_instream_width_padded()
-        count_width = int(self.get_nodeattr("depth")).bit_length()
+
+        gauge = self.is_sim_fifo_gauge()
+        if gauge:
+            count_width = 32
+            code_gen_dict["$FIFO_CORE$"] = "sim_fifo_gauge"
+            depth = 0
+        else:
+            count_width = int(self.get_nodeattr("depth")).bit_length()
+            code_gen_dict["$FIFO_CORE$"] = "q_srl"
+            depth = int(self.get_nodeattr("depth"))
+        code_gen_dict["$COUNT_WIDTH$"] = f"{count_width}"
         code_gen_dict["$COUNT_RANGE$"] = "[{}:0]".format(count_width - 1)
         code_gen_dict["$IN_RANGE$"] = "[{}:0]".format(in_width - 1)
         code_gen_dict["$OUT_RANGE$"] = "[{}:0]".format(in_width - 1)
         code_gen_dict["$WIDTH$"] = str(in_width)
-        code_gen_dict["$DEPTH$"] = str(self.get_nodeattr("depth"))
+        code_gen_dict["$DEPTH$"] = str(depth)
         # apply code generation to templates
         code_gen_dir = self.get_nodeattr("code_gen_dir_ipgen")
         with open(template_path, "r") as f:
@@ -107,7 +125,10 @@ class StreamingFIFO_rtl(StreamingFIFO, RTLBackend):
         ) as f:
             f.write(template)
 
-        shutil.copy(rtlsrc + "/Q_srl.v", code_gen_dir)
+        if self.is_sim_fifo_gauge():
+            shutil.copy(rtlsrc + "/fifo_gauge.sv", code_gen_dir)
+        else:
+            shutil.copy(rtlsrc + "/Q_srl.v", code_gen_dir)
         # set ipgen_path and ip_path so that HLS-Synth transformation
         # and stich_ip transformation do not complain
         self.set_nodeattr("ipgen_path", code_gen_dir)
@@ -119,7 +140,7 @@ class StreamingFIFO_rtl(StreamingFIFO, RTLBackend):
             code_gen_dir = self.get_nodeattr("code_gen_dir_ipgen")
 
             sourcefiles = [
-                "Q_srl.v",
+                "fifo_gauge.sv" if self.is_sim_fifo_gauge() else "Q_srl.v",
                 self.get_nodeattr("gen_top_module") + ".v",
             ]
 


### PR DESCRIPTION
This merges a feature developed by AMD that has not yet found its way into the official dev branch.

It allows infinite depth monitoring during XSI simulation by using SystemVerilog queues. This is used during simulation-based FIFO sizing.

See the original branch: https://github.com/Xilinx/finn/commits/feature/fifo_gauge_integration/