### PR TITLE
Add step to find unsupported layers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,8 @@ markers = [
    "bnn_u250: mark tests that execute U250 BNN tests",
    "bnn_kv260: mark tests that execute KV260 BNN tests",
    "bnn_pynq: mark tests that execute Pynq-Z1 BNN tests",
-   "bnn_zcu104: mark tests that execute ZCU104 BNN tests"
+   "bnn_zcu104: mark tests that execute ZCU104 BNN tests",
+   "analysis: mark tests that run analysis tests",
 ]
 norecursedirs = [
     "dist",

--- a/src/finn/analysis/fpgadataflow/unsupported_layers.py
+++ b/src/finn/analysis/fpgadataflow/unsupported_layers.py
@@ -1,0 +1,67 @@
+from collections import deque
+from qonnx.core.modelwrapper import ModelWrapper
+
+
+def unsupported_layers(model: ModelWrapper):
+    """
+    Check if all sink nodes are only reachable by paths with at most one
+    connected section of nodes which are supported by the FPGA.
+    """
+
+    def is_supported_node(node):
+        return node.domain == "finn.custom_op.fpgadataflow"
+
+    # Find source and sink nodes in the model
+    source_nodes = []
+    sink_nodes = []
+
+    inputs = model.graph.input
+    for inp in inputs:
+        # Nodes are not supported by python sets, so needing to do deduplication manually
+        for n in model.find_consumers(inp.name):
+            if n not in source_nodes:
+                source_nodes.append(n)
+
+    outputs = model.graph.output
+    for out in outputs:
+        n = model.find_producer(out.name)
+        if n not in sink_nodes:
+            sink_nodes.append(n)
+
+    # BFS to check paths
+    queue = deque()
+    # Track (node_id, in_green_section, has_seen_complete_green_section)
+    visited = []
+
+    # Initialize BFS with all source nodes
+    for source in source_nodes:
+        is_supported = is_supported_node(source)
+        queue.append((source, is_supported, False))
+        visited.append((source, is_supported, False))
+
+    while queue:
+        node, in_fpga_sec, seen_complete_fpga_section = queue.popleft()
+
+        # Process all successors
+        successors = model.find_direct_successors(node)
+        if successors is not None:
+            for successor in successors:
+                sucessor_supported = is_supported_node(successor)
+                fpga_section_end = seen_complete_fpga_section
+
+                # If transitioning from FPGA to Host, we've completed a FPGA section
+                if in_fpga_sec and not sucessor_supported:
+                    fpga_section_end = True
+
+                # If we've already seen a complete FPGA section and are about to start a new one
+                if seen_complete_fpga_section and not in_fpga_sec and sucessor_supported:
+                    # This path would create a second FPGA section
+                    return False, node
+
+                # Handle cycles
+                state = (successor, sucessor_supported, fpga_section_end)
+                if state not in visited:
+                    visited.append(state)
+                    queue.append((successor, sucessor_supported, fpga_section_end))
+
+    return True, None

--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -61,6 +61,7 @@ from finn.analysis.fpgadataflow.hls_synth_res_estimation import hls_synth_res_es
 from finn.analysis.fpgadataflow.op_and_param_counts import aggregate_dict_keys, op_and_param_counts
 from finn.analysis.fpgadataflow.post_synth_res import post_synth_res
 from finn.analysis.fpgadataflow.res_estimation import res_estimation, res_estimation_complete
+from finn.analysis.fpgadataflow.unsupported_layers import unsupported_layers
 from finn.builder.build_dataflow_config import (
     DataflowBuildConfig,
     DataflowOutputType,
@@ -389,6 +390,18 @@ def step_specialize_layers(model: ModelWrapper, cfg: DataflowBuildConfig):
     model = model.transform(SpecializeLayers(cfg._resolve_fpga_part()))
     model = model.transform(InferShapes())
     model = model.transform(InferDataTypes())
+    return model
+
+
+def step_check_unsupported_nodes(model: ModelWrapper, cfg: DataflowBuildConfig):
+    """Check if the model contains unsupported nodes for dataflow synthesis.
+    If unsupported nodes are found, raise an error with a list of those nodes."""
+
+    results = model.analysis(unsupported_layers)
+
+    if not results[0]:
+        raise FINNUserError(f"Unsupported combination of layers found after node {results[1].name}")
+
     return model
 
 
@@ -966,6 +979,7 @@ build_dataflow_step_lookup = {
     "step_streamline": step_streamline,
     "step_convert_to_hw": step_convert_to_hw,
     "step_specialize_layers": step_specialize_layers,
+    "step_check_unsupported_nodes": step_check_unsupported_nodes,
     "step_create_dataflow_partition": step_create_dataflow_partition,
     "step_target_fps_parallelization": step_target_fps_parallelization,
     "step_apply_folding_config": step_apply_folding_config,

--- a/tests/analysis/test_unsupported_layers.py
+++ b/tests/analysis/test_unsupported_layers.py
@@ -1,0 +1,232 @@
+import pytest
+
+import random
+import string
+from onnx import TensorProto, helper
+from qonnx.core.modelwrapper import ModelWrapper
+from qonnx.util.basic import qonnx_make_model
+
+from finn.analysis.fpgadataflow.unsupported_layers import unsupported_layers
+
+
+def get_random_name():
+    return "".join(random.choices(string.ascii_lowercase, k=10))
+
+
+def create_tensor():
+    return helper.make_tensor_value_info(get_random_name(), TensorProto.FLOAT, None)
+
+
+def create_node(inputs, outputs, fpga=False, name=None):
+    if fpga:
+        domain = "finn.custom_op.fpgadataflow"
+    else:
+        domain = "somethingelse"
+
+    return helper.make_node(
+        "CustomOp", [i.name for i in inputs], [o.name for o in outputs], domain=domain, name=name
+    )
+
+
+@pytest.mark.analysis
+def test_unsupported_layers_expected_fail():
+    inp1 = create_tensor()
+    inp2 = create_tensor()
+
+    n1n3 = create_tensor()
+    n2n3 = create_tensor()
+
+    n1 = create_node([inp1], [n1n3], fpga=False)
+    n2 = create_node([inp2], [n2n3], fpga=False)
+
+    n3n5 = create_tensor()
+    n3n4 = create_tensor()
+
+    n3 = create_node([n1n3, n2n3], [n3n4, n3n5], fpga=True)
+
+    n5n6 = create_tensor()
+    n4n6 = create_tensor()
+
+    n5 = create_node([n3n5], [n5n6], fpga=False)
+    n4 = create_node([n3n4], [n4n6], fpga=True)
+
+    n6n7 = create_tensor()
+
+    n6 = create_node([n5n6, n4n6], [n6n7], fpga=True)
+
+    out = create_tensor()
+
+    n7 = create_node([n6n7], [out], fpga=True)
+
+    mul_graph = helper.make_graph(
+        nodes=[n1, n2, n3, n4, n5, n6, n7],
+        name="g1",
+        inputs=[inp1, inp2],
+        outputs=[out],
+        value_info=[n1n3, n2n3, n3n4, n3n5, n5n6, n4n6, n6n7],
+    )
+
+    model = qonnx_make_model(mul_graph)
+    model = ModelWrapper(model)
+
+    ret = unsupported_layers(model)
+    assert ret[0] is False, "Model should not be supported, but was not detected as such"
+
+
+@pytest.mark.analysis
+def test_unsupported_layers():
+    inp1 = create_tensor()
+    inp2 = create_tensor()
+
+    n1n3 = create_tensor()
+    n2n3 = create_tensor()
+
+    n1 = create_node([inp1], [n1n3], fpga=False)
+    n2 = create_node([inp2], [n2n3], fpga=False)
+
+    n3n5 = create_tensor()
+    n3n4 = create_tensor()
+
+    n3 = create_node([n1n3, n2n3], [n3n4, n3n5], fpga=True)
+
+    n5n6 = create_tensor()
+    n4n6 = create_tensor()
+
+    n5 = create_node([n3n5], [n5n6], fpga=True)
+    n4 = create_node([n3n4], [n4n6], fpga=True)
+
+    n6n7 = create_tensor()
+
+    n6 = create_node([n5n6, n4n6], [n6n7], fpga=True)
+
+    out = create_tensor()
+
+    n7 = create_node([n6n7], [out], fpga=True)
+
+    mul_graph = helper.make_graph(
+        nodes=[n1, n2, n3, n4, n5, n6, n7],
+        name="g1",
+        inputs=[inp1, inp2],
+        outputs=[out],
+        value_info=[n1n3, n2n3, n3n4, n3n5, n5n6, n4n6, n6n7],
+    )
+
+    model = qonnx_make_model(mul_graph)
+    model = ModelWrapper(model)
+
+    ret = unsupported_layers(model)
+    assert ret[0] is True, "Model should be supported, but was not detected as such"
+
+
+@pytest.mark.analysis
+def test_unsupported_layers_loop():
+    inp1 = create_tensor()
+    inp2 = create_tensor()
+
+    n1n3 = create_tensor()
+    n2n3 = create_tensor()
+
+    n1 = create_node([inp1], [n1n3], fpga=False)
+    n2 = create_node([inp2], [n2n3], fpga=False)
+
+    n3n5 = create_tensor()
+    n3n4 = create_tensor()
+
+    n3 = create_node([n1n3, n2n3], [n3n4, n3n5], fpga=True)
+
+    n5n6 = create_tensor()
+    n4n6 = create_tensor()
+
+    n6n5 = create_tensor()
+
+    n5 = create_node([n3n5, n6n5], [n5n6], fpga=True)
+    n4 = create_node([n3n4], [n4n6], fpga=True)
+
+    n6n7 = create_tensor()
+
+    n6 = create_node([n5n6, n4n6], [n6n7, n6n5], fpga=True)
+
+    out = create_tensor()
+
+    n7 = create_node([n6n7], [out], fpga=True)
+
+    mul_graph = helper.make_graph(
+        nodes=[n1, n2, n3, n4, n5, n6, n7],
+        name="g1",
+        inputs=[inp1, inp2],
+        outputs=[out],
+        value_info=[n1n3, n2n3, n3n4, n3n5, n5n6, n4n6, n6n7],
+    )
+
+    model = qonnx_make_model(mul_graph)
+    model = ModelWrapper(model)
+
+    ret = unsupported_layers(model)
+    assert ret[0] is True, "Model should be supported, but was not detected as such"
+
+
+@pytest.mark.analysis
+def test_large_model():
+    inp1 = create_tensor()
+    inp2 = create_tensor()
+
+    n1n3 = create_tensor()
+    n2n4 = create_tensor()
+
+    n1 = create_node([inp1], [n1n3], fpga=False)
+    n2 = create_node([inp2], [n2n4], fpga=False)
+
+    n3n5 = create_tensor()
+    n4n5 = create_tensor()
+    n4n6 = create_tensor()
+
+    n3 = create_node([n1n3], [n3n5], fpga=True)
+    n4 = create_node([n2n4], [n4n5, n4n6], fpga=False)
+
+    out1 = create_tensor()
+
+    n6 = create_node([n4n6], [out1], fpga=False)
+
+    n5n7 = create_tensor()
+    n5n8 = create_tensor()
+
+    n5 = create_node([n3n5, n4n5], [n5n7, n5n8], fpga=True)
+
+    out2 = create_tensor()
+
+    n7 = create_node([n5n7], [out2], fpga=True)
+
+    n8n9 = create_tensor()
+
+    n8 = create_node([n5n8], [n8n9], fpga=True)
+
+    n9n10 = create_tensor()
+
+    n9 = create_node([n8n9], [n9n10], fpga=True, name="n9")
+
+    n10n11 = create_tensor()
+    n10n12 = create_tensor()
+
+    n10 = create_node([n9n10], [n10n11, n10n12], fpga=False, name="n10")
+
+    out3 = create_tensor()
+
+    n11 = create_node([n10n11], [out3], fpga=False, name="n11")
+
+    out4 = create_tensor()
+
+    n12 = create_node([n10n12], [out4], fpga=True, name="n12")
+
+    mul_graph = helper.make_graph(
+        nodes=[n1, n2, n3, n4, n5, n6, n7, n8, n9, n10, n11, n12],
+        name="g2",
+        inputs=[inp1, inp2],
+        outputs=[out1, out2, out3, out4],
+        value_info=[n1n3, n2n4, n3n5, n4n5, n4n6, n5n7, n5n8, n8n9, n9n10, n10n11, n10n12],
+    )
+
+    model = qonnx_make_model(mul_graph)
+    model = ModelWrapper(model)
+
+    ret = unsupported_layers(model)
+    assert ret[0] is False, "Model should not be supported, but was not detected as such"


### PR DESCRIPTION
Adds an additional step to the flow, which checks, after the specialize hardware step, if layers are left in the graph that have not been specialized. Layers at the start or and of the network are ignored, because they can be implemented in software on the host. If layers in the middle of the network are not specialized, the build process is stopped, as this will result in unrecoverable errors later on.

Implements https://github.com/eki-project/finn-plus/issues/24