### PR TITLE
Fix tests after recent data layout changes

### DIFF
--- a/ci/cfg/live_fifosizing.yml
+++ b/ci/cfg/live_fifosizing.yml
@@ -1,19 +1,112 @@
 [
-    # Real models
+    ### BNN-PYNQ ###
+    # cnv-w1a1
     {
-        "dut": ["vgg10"],
+        "dut": ["bnn-pynq"],
+        "model_path": [models/bnn-pynq/cnv-w1a1_qonnx.onnx],
+        "folding_config_file": [models/bnn-pynq/cnv-w1a1_folding_config.json],
+        "specialize_layers_config_file": [models/bnn-pynq/cnv-w1a1_specialize_layers.json],
         "live_fifo_sizing": [True],
-        "generate_outputs": [["bitfile", "pynq_driver", "deployment_package"]]
+        "generate_outputs": [["bitfile", "pynq_driver", "deployment_package"]],
+        "synth_clk_period_ns": [10],
     },
+    # cnv-w1a2
+    {
+        "dut": ["bnn-pynq"],
+        "model_path": [models/bnn-pynq/cnv-w1a2_qonnx.onnx],
+        "folding_config_file": [models/bnn-pynq/cnv-w1a2_folding_config.json],
+        "specialize_layers_config_file": [models/bnn-pynq/cnv-w1a2_specialize_layers.json],
+        "live_fifo_sizing": [True],
+        "generate_outputs": [["bitfile", "pynq_driver", "deployment_package"]],
+        "synth_clk_period_ns": [10],
+    },
+    # cnv-w2a2
+    {
+        "dut": ["bnn-pynq"],
+        "model_path": [models/bnn-pynq/cnv-w2a2_qonnx.onnx],
+        "folding_config_file": [models/bnn-pynq/cnv-w2a2_folding_config.json],
+        "specialize_layers_config_file": [models/bnn-pynq/cnv-w2a2_specialize_layers.json],
+        "live_fifo_sizing": [True],
+        "generate_outputs": [["bitfile", "pynq_driver", "deployment_package"]],
+        "synth_clk_period_ns": [10],
+    },
+    # tfc-w1a1
+    {
+        "dut": ["bnn-pynq"],
+        "model_path": [models/bnn-pynq/tfc-w1a1_qonnx.onnx],
+        "folding_config_file": [models/bnn-pynq/tfc-w1a1_folding_config.json],
+        "specialize_layers_config_file": [models/bnn-pynq/tfc-w1a1_specialize_layers.json],
+        "live_fifo_sizing": [True],
+        "generate_outputs": [["bitfile", "pynq_driver", "deployment_package"]],
+        "synth_clk_period_ns": [10],
+    },
+    # tfc-w1a2
+    {
+        "dut": ["bnn-pynq"],
+        "model_path": [models/bnn-pynq/tfc-w1a2_qonnx.onnx],
+        "folding_config_file": [models/bnn-pynq/tfc-w1a2_folding_config.json],
+        "specialize_layers_config_file": [models/bnn-pynq/tfc-w1a2_specialize_layers.json],
+        "live_fifo_sizing": [True],
+        "generate_outputs": [["bitfile", "pynq_driver", "deployment_package"]],
+        "synth_clk_period_ns": [10],
+    },
+    # tfc-w2a2
+    {
+        "dut": ["bnn-pynq"],
+        "model_path": [models/bnn-pynq/tfc-w2a2_qonnx.onnx],
+        "folding_config_file": [models/bnn-pynq/tfc-w2a2_folding_config.json],
+        "specialize_layers_config_file": [models/bnn-pynq/tfc-w2a2_specialize_layers.json],
+        "live_fifo_sizing": [True],
+        "generate_outputs": [["bitfile", "pynq_driver", "deployment_package"]],
+        "synth_clk_period_ns": [10],
+    },
+
+    # GTSRB (cnv-w1a1)
+    {
+        "dut": ["gtsrb"],
+        "live_fifo_sizing": [True],
+        "generate_outputs": [["bitfile", "pynq_driver", "deployment_package"]],
+        "synth_clk_period_ns": [10],
+    },
+
+    #KWS (MLP)
+    {
+        "dut": ["kws"],
+        "live_fifo_sizing": [True],
+        "generate_outputs": [["bitfile", "pynq_driver", "deployment_package"]],
+        "synth_clk_period_ns": [10],
+    },
+
+    # Cybersecurity (MLP)
+    {
+        "dut": ["cybsec"],
+        "live_fifo_sizing": [True],
+        "generate_outputs": [["bitfile", "pynq_driver", "deployment_package"]],
+        "synth_clk_period_ns": [10],
+    },
+
+    # MobileNetV1 (ImageNet)
     {
         "dut": ["mobilenetv1"],
         "live_fifo_sizing": [True],
-        "generate_outputs": [["bitfile", "pynq_driver", "deployment_package"]]
+        "generate_outputs": [["bitfile", "pynq_driver", "deployment_package"]],
+        "synth_clk_period_ns": [10],
     },
+
+    # VGG-10 (1D CNN) (RadioML)
+    {
+        "dut": ["vgg10"],
+        "live_fifo_sizing": [True],
+        "generate_outputs": [["bitfile", "pynq_driver", "deployment_package"]],
+        "synth_clk_period_ns": [10],
+    },
+
+    # ResNet-50 (ImageNet)
     {
         "dut": ["resnet50"],
         "live_fifo_sizing": [True],
-        "generate_outputs": [["bitfile", "pynq_driver", "deployment_package"]]
+        "generate_outputs": [["bitfile", "pynq_driver", "deployment_package"]],
+        "synth_clk_period_ns": [10],
     },
 
     # Synthetic non-linear models
@@ -30,7 +123,8 @@
         "rb_num_layers": [4, 8, 16],
 
         "live_fifo_sizing": [True],
-        "generate_outputs": [["bitfile", "pynq_driver", "deployment_package"]]
+        "generate_outputs": [["bitfile", "pynq_driver", "deployment_package"]],
+        "synth_clk_period_ns": [10],
     },
     {
         "dut": ["synthetic_nonlinear"],
@@ -45,6 +139,7 @@
         "rb_num_layers": [4, 8, 16],
 
         "live_fifo_sizing": [True],
-        "generate_outputs": [["bitfile", "pynq_driver", "deployment_package"]]
+        "generate_outputs": [["bitfile", "pynq_driver", "deployment_package"]],
+        "synth_clk_period_ns": [10],
     }
 ]

--- a/ci/cfg/microbenchmark_basic.yml
+++ b/ci/cfg/microbenchmark_basic.yml
@@ -20,29 +20,32 @@
         "ram_style": ["distributed"],
         "ram_style_thr": ["distributed"],
 
+        "backend": ["hls"],
+
         "dut_duplication": [1],
 
         "generate_outputs": [["estimate_reports", "stitched_ip", "rtlsim_performance", "out_of_context_synth", "bitfile", "pynq_driver", "deployment_package"]]
     },
 
     # Transformer Dummy
-    {
-        "dut": ["transformer"],
-        "seed": [12],
+    # Temporarily disabled due to streamlining issues!
+    # {
+    #     "dut": ["transformer"],
+    #     "seed": [12],
 
-        "calibration_passes": [32],
+    #     "calibration_passes": [32],
 
-        "model_num_heads": [1],
-        "model_num_layers": [1],
-        "model_bias":[true],
-        "model_emb_dim": [32],
-        "model_mlp_dim": [192],
-        "model_seq_len": [64],
-        "model_bits": [2],
-        "model_norm": ["none"],
-        "model_mask": ["none"],
-        "model_positional_encoding": ["binary"],
+    #     "model_num_heads": [1],
+    #     "model_num_layers": [1],
+    #     "model_bias":[true],
+    #     "model_emb_dim": [32],
+    #     "model_mlp_dim": [192],
+    #     "model_seq_len": [64],
+    #     "model_bits": [2],
+    #     "model_norm": ["none"],
+    #     "model_mask": ["none"],
+    #     "model_positional_encoding": ["binary"],
 
-        "generate_outputs": [["estimate_reports", "bitfile", "pynq_driver", "deployment_package"]]
-    }
+    #     "generate_outputs": [["estimate_reports", "bitfile", "pynq_driver", "deployment_package"]]
+    # }
 ]

--- a/ci/cfg/regression_extended.yml
+++ b/ci/cfg/regression_extended.yml
@@ -64,7 +64,7 @@
     # ResNet-50
     {
         "dut": ["resnet50"],
-        "board": ["U280"],
+        "board": ["U55C"],
         "synth_clk_period_ns": [4],
         "rtlsim_batch_size": [3],
         # no deployment package because Alveo deployment is not yet supported by CI
@@ -86,26 +86,28 @@
     # }
 
     # 5x RadioML Transformer models
-    {
-        "dut": ["transformer"],
-        "seed": [12],
-        "model_dir": ["models/rml_transformer_0",
-                      "models/rml_transformer_a",
-                      "models/rml_transformer_b",
-                      "models/rml_transformer_c",
-                      "models/rml_transformer_d",],
-        "board": ["RFSoC2x2"],
-        "synth_clk_period_ns": [10],
-        "generate_outputs": [["estimate_reports", "bitfile", "pynq_driver", "deployment_package"]]
-    },
+    # Temporarily disabled due to streamlining issues!
+    # {
+    #     "dut": ["transformer"],
+    #     "seed": [12],
+    #     "model_dir": ["models/rml_transformer_0",
+    #                   "models/rml_transformer_a",
+    #                   "models/rml_transformer_b",
+    #                   "models/rml_transformer_c",
+    #                   "models/rml_transformer_d",],
+    #     "board": ["RFSoC2x2"],
+    #     "synth_clk_period_ns": [10],
+    #     "generate_outputs": [["estimate_reports", "bitfile", "pynq_driver", "deployment_package"]]
+    # },
 
     # 1x RadioML Conformer model
-    {
-        "dut": ["transformer"],
-        "seed": [12],
-        "model_dir": ["models/rml_conformer"],
-        "board": ["RFSoC2x2"],
-        "synth_clk_period_ns": [10],
-        "generate_outputs": [["estimate_reports", "bitfile", "pynq_driver", "deployment_package"]]
-    }
+    # Temporarily disabled due to streamlining issues!
+    # {
+    #     "dut": ["transformer"],
+    #     "seed": [12],
+    #     "model_dir": ["models/rml_conformer"],
+    #     "board": ["RFSoC2x2"],
+    #     "synth_clk_period_ns": [10],
+    #     "generate_outputs": [["estimate_reports", "bitfile", "pynq_driver", "deployment_package"]]
+    # }
 ]

--- a/ci/cfg/regression_extended.yml
+++ b/ci/cfg/regression_extended.yml
@@ -64,8 +64,9 @@
     # ResNet-50
     {
         "dut": ["resnet50"],
-        "board": ["U55C"],
-        "synth_clk_period_ns": [4],
+        "board": ["U250"],
+        "synth_clk_period_ns": [5],
+        # NOTE: At least without manual floorplanning, timing will not meet 200 MHz and drop down automatically!
         "rtlsim_batch_size": [3],
         # no deployment package because Alveo deployment is not yet supported by CI
         "generate_outputs": [["estimate_reports", "rtlsim_performance", "stitched_ip", "out_of_context_synth", "bitfile"]],

--- a/src/finn/benchmarking/dut/resnet50.yml
+++ b/src/finn/benchmarking/dut/resnet50.yml
@@ -1,7 +1,9 @@
 model_path: models/resnet50/resnet50_w1a2_exported.onnx
 folding_config_file: models/resnet50/U250_folding_config_live_fifo.json
 specialize_layers_config_file: models/resnet50/U250_specialize_layers.json
-vitis_floorplan_file: models/resnet50/floorplan_resnet50.json
+
+# This floorplan is for U250 (4 SLRs), do not specify it here as we target different devices
+#vitis_floorplan_file: models/resnet50/floorplan_resnet50.json
 
 steps:
   - finn.builder.custom_step_library.resnet.step_resnet50_tidy # Custom step

--- a/src/finn/benchmarking/dut/resnet50.yml
+++ b/src/finn/benchmarking/dut/resnet50.yml
@@ -2,8 +2,11 @@ model_path: models/resnet50/resnet50_w1a2_exported.onnx
 folding_config_file: models/resnet50/U250_folding_config_live_fifo.json
 specialize_layers_config_file: models/resnet50/U250_specialize_layers.json
 
-# This floorplan is for U250 (4 SLRs), do not specify it here as we target different devices
 #vitis_floorplan_file: models/resnet50/floorplan_resnet50.json
+# This floorplan is for U250 (4 SLRs), do not specify it here for two reasons:
+# 1) We might want to target different devices
+# 2) It appears to cause the following error for U250 (TODO):
+# ERROR: [v++ 60-397] Max number of compute units in binary 'xcl_v++' exceeded. The target platform only supports 60 compute units in a binary.
 
 steps:
   - finn.builder.custom_step_library.resnet.step_resnet50_tidy # Custom step

--- a/src/finn/custom_op/fpgadataflow/hlsbackend.py
+++ b/src/finn/custom_op/fpgadataflow/hlsbackend.py
@@ -331,7 +331,7 @@ compilation transformations?
             folded_ishape = self.get_folded_input_shape(i)
             inp_val = context[inp]
             # Make sure the input has the right container datatype
-            if inp_val.dtype is not np.float32:
+            if inp_val.dtype != np.float32:
                 # Issue a warning to make the user aware of this type-cast
                 log.warning(
                     f"{node.name}: Changing input container datatype from "

--- a/src/finn/custom_op/fpgadataflow/rtl/streamingfifo_rtl.py
+++ b/src/finn/custom_op/fpgadataflow/rtl/streamingfifo_rtl.py
@@ -229,15 +229,22 @@ class StreamingFIFO_rtl(StreamingFIFO, RTLBackend):
         return verilog_files
 
     def prepare_rtlsim(self):
-        assert self.get_nodeattr("impl_style") != "vivado", (
-            "StreamingFIFO impl_style "
-            "cannot be vivado for rtlsim. Only impl_style=rtl supported."
-        )
+        # TODO: Support simulation of vivado-style FIFOs,
+        # or ensure node-by-node rtlsim is always skipped for FIFOs in general
+        if self.get_nodeattr("impl_style") == "vivado":
+            log.warning(
+                f"Trying to prepare rtlsim for {self.onnx_node.name}, but impl_style "
+                "is set to vivado, which is not supported for simulation. Skipping. "
+                "Simulation will fall back to Python simulation."
+            )
+            raise NotImplementedError()
         return super().prepare_rtlsim()
 
     def execute_node(self, context, graph):
         mode = self.get_nodeattr("exec_mode")
-        if mode == "cppsim":
+        impl_style = self.get_nodeattr("impl_style")
+        if mode == "cppsim" or impl_style == "vivado":
+            # Fall back to Python simulation (no-op) for vivado-style FIFOs
             StreamingFIFO.execute_node(self, context, graph)
         elif mode == "rtlsim":
             RTLBackend.execute_node(self, context, graph)

--- a/src/finn/custom_op/fpgadataflow/rtlbackend.py
+++ b/src/finn/custom_op/fpgadataflow/rtlbackend.py
@@ -99,7 +99,17 @@ class RTLBackend(ABC):
                 exp_ishape = tuple(self.get_normal_input_shape(i))
                 folded_ishape = self.get_folded_input_shape(i)
                 inp_val = context[inp]
-                assert str(inp_val.dtype) == "float32", "Input datatype is not float32"
+                # Make sure the input has the right container datatype
+                if inp_val.dtype != np.float32:
+                    # Issue a warning to make the user aware of this type-cast
+                    log.warning(
+                        f"{node.name}: Changing input container datatype from "
+                        f"{inp_val.dtype} to {np.float32}"
+                    )
+                    # Convert the input to floating point representation as the
+                    # container datatype
+                    inp_val = inp_val.astype(np.float32)
+
                 assert inp_val.shape == exp_ishape, "Input shape doesn't match expected shape."
                 export_idt = self.get_input_datatype(i)
 

--- a/src/finn/interface/manage_deps.py
+++ b/src/finn/interface/manage_deps.py
@@ -30,8 +30,8 @@ FINN_DEPS = {
         True,
     ),
     "qonnx": (
-        "https://github.com/iksnagreb/qonnx.git",
-        "3d3d8964dbc5355d5c9be855d87b7b442508e3a4",
+        "https://github.com/fpjentzsch/qonnx.git",
+        "fab7dca2e1734cf8767fa3f6161f674aaa26a402",
         True,
     ),
     "dataset_loading": (

--- a/src/finn/transformation/fpgadataflow/convert_to_hw_layers.py
+++ b/src/finn/transformation/fpgadataflow/convert_to_hw_layers.py
@@ -217,6 +217,12 @@ class InferThresholdingLayer(Transformation):
                     please run RoundAndClipThresholds to convert thresholds to integer."""
                 )
 
+                # TODO: this should be removed in favor of proper layout handling in the frontend
+                #  this workaround is currently still needed to handle standalone NCHW MTs at the
+                #  input of the graph, e.g., for cnv (bnn-pynq) models
+                # NOTE: careful, this requires proper layout annotation for input AND output,
+                #  otherwise the graph could break because only one of two Transpose gets inserted
+
                 # check layout of inputs/outputs, and convert if needed
                 # check layout and convert if necessary
                 thl_in_layout = model.get_tensor_layout(thl_input)

--- a/src/finn/transformation/fpgadataflow/prepare_rtlsim.py
+++ b/src/finn/transformation/fpgadataflow/prepare_rtlsim.py
@@ -69,4 +69,7 @@ class PrepareRTLSim(NodeLocalTransformation):
             except KeyError:
                 # exception if op_type is not supported
                 raise Exception("Custom op_type %s is currently not supported." % op_type)
+            except NotImplementedError:
+                # Some custom ops (Vivado StreamingFIFO) may gracefully skip rtlsim
+                pass
         return (node, False)

--- a/src/finn/transformation/fpgadataflow/set_fifo_depths.py
+++ b/src/finn/transformation/fpgadataflow/set_fifo_depths.py
@@ -457,6 +457,7 @@ class InsertAndSetFIFODepths(Transformation):
         model.set_metadata_prop("wrapper_filename", "")
         model.set_metadata_prop("vivado_stitch_vlnv", "")
         model.set_metadata_prop("vivado_stitch_ifnames", "")
+        model.set_metadata_prop("exec_mode", "")
 
         # reflect final values in attributes
         for node in model.graph.node:

--- a/src/finn/transformation/qonnx/convert_qonnx_to_finn.py
+++ b/src/finn/transformation/qonnx/convert_qonnx_to_finn.py
@@ -93,6 +93,7 @@ class ConvertQONNXtoFINN(Transformation):
         )
         # Recompute datatypes
         model = model.transform(InferDataTypes())
+        model = model.transform(InferDataLayouts())
         # Convert AvgPool -> Mul -> Trunc structure to QuantAvgPool2d
         model = model.transform(AvgPoolAndTruncToQuantAvgPool())
         # Remove empty padding if it exists

--- a/src/finn/transformation/streamline/__init__.py
+++ b/src/finn/transformation/streamline/__init__.py
@@ -38,6 +38,7 @@ from qonnx.transformation.general import (
     GiveReadableTensorNames,
     GiveUniqueNodeNames,
 )
+from qonnx.transformation.infer_data_layouts import InferDataLayouts
 from qonnx.transformation.infer_datatypes import InferDataTypes
 from qonnx.transformation.remove import RemoveIdentityOps
 
@@ -100,4 +101,6 @@ class Streamline(Transformation):
             model = model.transform(GiveUniqueNodeNames())
             model = model.transform(GiveReadableTensorNames())
             model = model.transform(InferDataTypes())
+            model = model.transform(InferDataLayouts())
+
         return (model, False)

--- a/tests/transformation/streamline/test_streamline_fc.py
+++ b/tests/transformation/streamline/test_streamline_fc.py
@@ -90,7 +90,9 @@ def test_streamline_fc(size, wbits, abits):
     model = model.transform(RemoveUnusedTensors())
     assert len(model.graph.initializer) == 11
     assert len(model.graph.value_info) == 21
-    assert len(model.graph.quantization_annotation) == 20
+    # The first tensor (input to the Reshape) doesn't have a quantization annotation (why?),
+    # but it does have a layout annotation now, which is also stored as "quantization_annotation"
+    assert len(model.graph.quantization_annotation) == 21
     produced_ctx = oxe.execute_onnx(model, input_dict, True)
     produced = produced_ctx[model.graph.output[0].name]
     assert np.isclose(expected, produced, atol=1e-3).all()


### PR DESCRIPTION
- Adjusts some streamlining test conditions to recent layout inference changes
- Fixes https://github.com/eki-project/finn-plus/issues/86 by improving layout inference and doing it more often
- Fixes https://github.com/eki-project/finn-plus/issues/85 by allowing node-by-node rtlsim on FIFOs for now
- Fixes (RN-50) or disables (Transformer) CI regression test configs that are currently broken
- Re-apply and fix https://github.com/eki-project/finn-plus/pull/31 to RTLBackend, was only pulled into HLSBackend after recent refactoring