### PR TITLE
Fixed incorrect path resolution for repository-local settings files

### DIFF
--- a/src/finn/interface/interface_globals.py
+++ b/src/finn/interface/interface_globals.py
@@ -25,7 +25,7 @@ def _resolve_settings_path() -> Path | None:
         error(f"Settings path specified via FINN_SETTINGS, but settings could not be found at {p}!")
         return None
     paths = [
-        Path(__file__).parent.parent / "settings.yaml",
+        Path(__file__).parent.parent.parent.parent / "settings.yaml",
         Path.home() / ".finn" / "settings.yaml",
         Path.home() / ".config" / "settings.yaml",
     ]

--- a/src/finn/interface/interface_utils.py
+++ b/src/finn/interface/interface_utils.py
@@ -117,12 +117,12 @@ def resolve_deps_path(deps: Path | None, settings: dict) -> Path | None:
     if "FINN_DEPS" in os.environ.keys():
         p = Path(os.environ["FINN_DEPS"])
         if not p.is_absolute():
-            return Path(__file__).parent.parent / p
+            return Path(__file__).parent.parent.parent.parent / p
         return p
     if "FINN_DEPS" in settings.keys():
         p = Path(settings["FINN_DEPS"])
         if not p.is_absolute():
-            return Path(__file__).parent.parent / p
+            return Path(__file__).parent.parent.parent.parent / p
         return p
     return None
 


### PR DESCRIPTION
As the title says, settings files in `finn-plus/settings.yaml` were not found correctly because after moving  `run_finn.py` to the `src` directory, the relative path that the file looks at was not changed. This is now fixed and instead of the settings file in `~`, now the local one is found first. 