### PR TITLE
Create snapshots on build failures

### DIFF
--- a/src/finn/util/exception.py
+++ b/src/finn/util/exception.py
@@ -1,3 +1,15 @@
+from __future__ import annotations
+
+import shutil
+from datetime import datetime
+from pathlib import Path
+from qonnx.core.modelwrapper import ModelWrapper
+from typing import Callable
+
+import finn
+from finn.builder.build_dataflow_config import DataflowBuildConfig
+from finn.util.basic import make_build_dir
+
 """
 FINNError is the base class for all errors.
 FINNUserError is a purely user-facing error that has nothing to do with FINNs internals
@@ -41,3 +53,49 @@ class FINNDataflowError(FINNInternalError):
 
     def __init__(self, *args: object) -> None:
         super().__init__(*args)
+
+
+# Alias for a build flow step function apply function
+StepFunction = Callable[[ModelWrapper, DataflowBuildConfig], ModelWrapper]
+
+
+def snapshot_on_exception(
+    snapshot_finn: bool = False,
+    snapshot_config: bool = True,
+    snapshot_model: bool = True,
+    snapshot_buildlog: bool = True,
+) -> Callable[[StepFunction], StepFunction]:
+    """Apply this decorator to any step function with the signature
+    ```
+    def step_...(model: ModelWrapper, cfg: DataflowBuildConfig) -> ModelWrapper:
+            ...
+    ```
+    to, in case an exception is raised, snapshot the ONNX model directly after the crash, as
+    well as a snapshot of FINN itself, as well as the build config and the dataflow build log"""
+
+    def decorator(step: StepFunction) -> StepFunction:
+        def wrapped(model: ModelWrapper, cfg: DataflowBuildConfig) -> ModelWrapper:
+            try:
+                return step(model, cfg)
+            except Exception as e:
+                date = datetime.today().strftime("%d_%m_%Y__%I_%M_%S")
+                path = Path(make_build_dir(f"crash_{date}_"))
+                if snapshot_model:
+                    model.save(str(path / "snapshot_model.onnx"))
+                if snapshot_config:
+                    yaml = str(cfg.to_yaml())
+                    with (path / "cfg.yaml").open("w+") as f:
+                        f.write(yaml)
+                if snapshot_finn:
+                    finn_root = Path(finn.__file__).parent
+                    shutil.copytree(finn_root, path / "finn")
+                if snapshot_buildlog and cfg.output_dir is not None:
+                    shutil.copy(
+                        Path(cfg.output_dir) / "build_dataflow.log", path / "build_dataflow.log"
+                    )
+                raise e
+
+        wrapped.__name__ = step.__name__
+        return wrapped
+
+    return decorator

--- a/src/finn/util/exception.py
+++ b/src/finn/util/exception.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import shutil
 from datetime import datetime
 from pathlib import Path
@@ -81,7 +82,22 @@ def snapshot_on_exception(
                 date = datetime.today().strftime("%d_%m_%Y__%I_%M_%S")
                 path = Path(make_build_dir(f"crash_{date}_"))
                 if snapshot_model:
-                    model.save(str(path / "snapshot_model.onnx"))
+                    # Get the frame where the exception was raised, get it's frame object,
+                    # and from it all locals, hopefully containing our ModelWrapper object
+                    error_locals = inspect.trace()[-1][0].f_locals
+                    modelwrappers = {
+                        k: v for k, v in error_locals.items() if isinstance(v, ModelWrapper)
+                    }
+                    if "model" in modelwrappers.keys():
+                        modelwrappers["model"].save(
+                            str(path / "transformation_model_snapshot.onnx")
+                        )
+                    elif len(modelwrappers.keys()) > 0:
+                        next(iter(modelwrappers.values())).save(
+                            str(path / "likely_transformation_model_snapshot.onnx")
+                        )
+                    else:
+                        model.save(str(path / "before_failed_transformation_model_snapshot.onnx"))
                 if snapshot_config:
                     yaml = str(cfg.to_yaml())
                     with (path / "cfg.yaml").open("w+") as f:


### PR DESCRIPTION
For debugging new transformations or steps, it is often useful to have the model directly available to inspect. Additionally, when supporting users, having a full copy of their setup is helpful to help debugging.

This PR introduces a decorator, that, when applied to buildflow steps, catches any exception, snapshots the current state (the ONNX model just before the failure occurred, the FINN source tree, the YAML of the current `DataflowBuildConfig` and the log until the exception). Afterwards it re-raises the exception to be handled by FINN as usual.
If I remember correctly, you @iksnagreb also wanted to have something like this. Is there something you'd want to add or change? 

TODOs:
- [ ] Support models after `step_create_dataflow_partition` was executed (recursively save all nested models)
- [ ] Automatically wrap every step in the build flow with the decorator if needed
- [ ] Include the exception itself into the snapshots `build_dataflow.log` 
- [ ] Maybe also save all (FINN-related) environment variables?
- [ ] Automatically provide a zip of the data in the output directory?

Generally, I am not sure that a decorator is the right way to implement this. It might just as well be a `DataflowBuildConfig` flag and integrate into `build_dataflow.py`.