### PR TITLE
Add paths to PATH in set_synthesis_tools_paths

### DIFF
--- a/src/finn/interface/interface_utils.py
+++ b/src/finn/interface/interface_utils.py
@@ -1,3 +1,5 @@
+"""Utilities for the FINN command line interface."""
+
 from __future__ import annotations
 
 import os
@@ -71,8 +73,7 @@ def set_synthesis_tools_paths() -> None:
 
         # Append to the search path just in case it was missing before, if
         # already in there adding again should do nothing
-        os.environ["PATH"] += \
-            os.pathsep + str((Path(envname_path) / "bin").absolute())
+        os.environ["PATH"] += os.pathsep + str((Path(envname_path) / "bin").absolute())
 
     if (
         "PLATFORM_REPO_PATHS" not in os.environ.keys()

--- a/src/finn/interface/interface_utils.py
+++ b/src/finn/interface/interface_utils.py
@@ -69,6 +69,11 @@ def set_synthesis_tools_paths() -> None:
             warning(f"Path for {toolname} found, but executable not found in {p}!")
         # TODO: simply check "which" instead?
 
+        # Append to the search path just in case it was missing before, if
+        # already in there adding again should do nothing
+        os.environ["PATH"] += \
+            os.pathsep + str((Path(envname_path) / "bin").absolute())
+
     if (
         "PLATFORM_REPO_PATHS" not in os.environ.keys()
         or not Path(os.environ["PLATFORM_REPO_PATHS"]).exists()


### PR DESCRIPTION
When setting up my development environment in PyCharm it does not seem that easy to add something to the PATH in advance. While I can overwrite the PATH and set arbitrary other environment variables, there seem to be no easy equivalent of running a `source` command prior to executing a configuration... As we otherwise expect the tools' search path to be there anyway, adding them again should not break anything.