### PR TITLE
Fix cybersecurity example model file

### DIFF
--- a/models/cybsec/unsw_nb15-mlp-w2a2.onnx.dvc
+++ b/models/cybsec/unsw_nb15-mlp-w2a2.onnx.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 5f0aadb2921bd906a8f44474cf4de4d9
-  size: 202459
+- md5: 8a800475e362db74107d3f61abcba8e4
+  size: 197397
   hash: md5
   path: unsw_nb15-mlp-w2a2.onnx


### PR DESCRIPTION
The cybersecurity example model taken from finn-examples was incorrectly configured (8 bit activation quant after first MVAU instead of 2 bit).

This updates the model to the fixed version from https://github.com/Xilinx/finn-examples/releases, updated on July 18, 2025.