### PR TITLE
[Folding] Derive SetFolding maximum PE fallback from output shape

### DIFF
--- a/src/finn/transformation/fpgadataflow/set_folding.py
+++ b/src/finn/transformation/fpgadataflow/set_folding.py
@@ -26,6 +26,7 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""Automatically sets folding, i.e., parallelism attributes for all FINN operators."""
 
 import functools
 
@@ -46,12 +47,14 @@ from finn.util.logging import log
 
 
 def divisors(num):
+    """Yield divisors of num."""
     for x in range(1, num + 1):
         if (num % x) == 0:
             yield x
 
 
 def common_divisors(numbers):
+    """Return common divisors of the list of numbers."""
     separate_divisors = []
     for num in numbers:
         individual_divisors = list(divisors(num))
@@ -107,12 +110,14 @@ class SetFolding(Transformation):
     """
 
     def __init__(self, target_cycles_per_frame=1000, mvau_wwidth_max=36, two_pass_relaxation=True):
+        """Initializes the folding target and constraints."""
         super().__init__()
         self.target_cycles_per_frame = target_cycles_per_frame
         self.mvau_wwidth_max = mvau_wwidth_max
         self.two_pass_relaxation = two_pass_relaxation
 
     def optimize_attribute_val(self, node_inst, max_val, attr_name):
+        """Optimize the folding attribute until the target cycles are met."""
         node_inst.set_nodeattr(attr_name, 1)
         for val in divisors(max_val):
             node_inst.set_nodeattr(attr_name, val)
@@ -122,6 +127,7 @@ class SetFolding(Transformation):
                 break
 
     def apply(self, model):
+        """Apply SetFolding to all supported nodes in the model."""
         graph = model.graph
         # these ops use PE parallelism, up to a max value of NumChannels
         pe_ops = [


### PR DESCRIPTION
Note: Previously this assumed identical input and output shape for PE-ops, which might not always be the case, e.g., Reshape.

As PE refers to the output parallelism, the fallback should be derived from the output shape to get valid folding.