### PR TITLE
Fix: Move GiveUniqueNodeNames() out of SpecializeLayers loop

### DIFF
--- a/src/finn/transformation/fpgadataflow/specialize_layers.py
+++ b/src/finn/transformation/fpgadataflow/specialize_layers.py
@@ -310,7 +310,10 @@ class SpecializeLayers(Transformation):
             graph.node.insert(node_ind, new_node)
             # remove old nodes
             graph.node.remove(node)
+            graph_modified = True
+
+        if graph_modified:
             # update node names to reflect new op types
             model = model.transform(GiveUniqueNodeNames())
-            graph_modified = True
+
         return (model, graph_modified)


### PR DESCRIPTION
This caused exploding runtime (minutes instead of < 1 second) and unexpected ordering of model.graph.node.