### PR TITLE
Fix typo in dut file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ numpy = "1.26.4"  # numpy<=1.26.4 required by brevitas
 # Upgrading onnxruntime fixes some MaxPool edge case which however requires onnx
 # to be upgraded to produce a consistent model, but this in turn cannot be done
 # due to the model IR version support issue...
-scipy = "~1.15.0"   
+scipy = "~1.15.0"
 onnx = "1.17.0"
 onnxruntime = "1.20.1"
 onnxscript = ">=0.5.0"                                # TODO: the onnx-passes installation will overwrite this version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ numpy = "1.26.4"  # numpy<=1.26.4 required by brevitas
 # Upgrading onnxruntime fixes some MaxPool edge case which however requires onnx
 # to be upgraded to produce a consistent model, but this in turn cannot be done
 # due to the model IR version support issue...
+scipy = "~1.15.0"   
 onnx = "1.17.0"
 onnxruntime = "1.20.1"
 onnxscript = ">=0.5.0"                                # TODO: the onnx-passes installation will overwrite this version

--- a/src/finn/benchmarking/dut/bnn-pynq.yml
+++ b/src/finn/benchmarking/dut/bnn-pynq.yml
@@ -29,4 +29,4 @@ steps:
   - step_deployment_package
 
 # Workaround for auto FIFO-sizing from finn-examples
-default_swg_exceptions: True
+default_swg_exception: True


### PR DESCRIPTION
Fixes a typo that causes the CI to crash for the bnn-pynq network.