### PR TITLE
fix(settings): settings.yaml not work

### DIFF
--- a/src/finn/interface/settings.py
+++ b/src/finn/interface/settings.py
@@ -293,7 +293,7 @@ class FINNSettings(BaseModel):
         modified_data = self.model_dump()
         for key in data.keys():
             lkey = key.lower()
-            if lkey in modified_data:
+            if lkey in modified_data data[key] is not None:
                 modified_data[lkey] = data[key]
         try:
             new_model = FINNSettings.model_validate(modified_data)


### PR DESCRIPTION
When CLI options such as dependency-path, dependency-definitions, or build-dir are not explicitly provided, Click passes them as None. These None values are currently forwarded to FINNSettings.init() and then applied through update_from(). Since update_from() does not filter out None values, they override the values loaded from settings.yaml. Consequently, valid user settings such as finn_deps, finn_deps_definitions, and finn_build_dir may be ignored and replaced by default values.