### PR TITLE
Add SLURM_EXCLUDE_NODES to CI configuration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,6 +34,9 @@ variables:
   SLURM_PARTITION:
     description: "Slurm partition (e.g., normal, largemem, fpga, gpu)"
     value: "fpga"
+  SLURM_EXCLUDE_NODES:
+    description: "Slurm nodes, which should not be used by the CI"
+    value: "fpga[1607-1614]"
   SLURM_QOS:
     description: "Optional --exclusive or QoS option (include --qos, e.g., --qos express)"
     value: ""
@@ -157,7 +160,7 @@ FINN Test Suite 2022.2:
     paths:
       - deps
   variables:
-    SCHEDULER_PARAMETERS: "-A $PROJECT_ACCOUNT -p $SLURM_PARTITION -t $SLURM_TIMEOUT $SLURM_QOS --nodes 1 --ntasks 1 --exclusive"
+    SCHEDULER_PARAMETERS: "-A $PROJECT_ACCOUNT -p $SLURM_PARTITION -t $SLURM_TIMEOUT $SLURM_QOS --nodes 1 --ntasks 1 --exclusive --exclude $SLURM_EXCLUDE_NODES"
     PYTEST_PARALLEL: "$CPU_CORES"
   extends: .setup_full_2022_2
   script:

--- a/ci/.gitlab-bench.yml
+++ b/ci/.gitlab-bench.yml
@@ -27,7 +27,7 @@ FINN Build:
     - job: Build
       pipeline: $PARENT_PIPELINE_ID
   variables:
-    SCHEDULER_PARAMETERS: "-A $PROJECT_ACCOUNT -p $SLURM_PARTITION -t $SLURM_TIMEOUT $SLURM_QOS --nodes 1 --ntasks 1 --cpus-per-task $CPU_CORES_BENCH --mem $MEM_BENCH --array 0-$( expr $PARALLEL_JOBS - 1 )"
+    SCHEDULER_PARAMETERS: "-A $PROJECT_ACCOUNT -p $SLURM_PARTITION -t $SLURM_TIMEOUT $SLURM_QOS --nodes 1 --ntasks 1 --exclude $SLURM_EXCLUDE_NODES --cpus-per-task $CPU_CORES_BENCH --mem $MEM_BENCH --array 0-$( expr $PARALLEL_JOBS - 1 )"
     NUM_DEFAULT_WORKERS: "$CPU_CORES_BENCH"
   extends: .setup_full_2024_2
   script:
@@ -120,7 +120,7 @@ FINN Build (Follow-up):
       pipeline: $PARENT_PIPELINE_ID
     - job: Result Collection
   variables:
-    SCHEDULER_PARAMETERS: "-A $PROJECT_ACCOUNT -p $SLURM_PARTITION -t $SLURM_TIMEOUT $SLURM_QOS --nodes 1 --ntasks 1 --cpus-per-task $CPU_CORES_BENCH --mem $MEM_BENCH --array 0-$( expr $PARALLEL_JOBS - 1 )"
+    SCHEDULER_PARAMETERS: "-A $PROJECT_ACCOUNT -p $SLURM_PARTITION -t $SLURM_TIMEOUT $SLURM_QOS --nodes 1 --ntasks 1 --exclude $SLURM_EXCLUDE_NODES --cpus-per-task $CPU_CORES_BENCH --mem $MEM_BENCH --array 0-$( expr $PARALLEL_JOBS - 1 )"
     NUM_DEFAULT_WORKERS: "$CPU_CORES_BENCH"
   extends: .setup_full_2024_2
   script:


### PR DESCRIPTION
Added SLURM_EXCLUDE_NODES variable to exclude specific nodes during CI.