### PR TITLE
Added vivado_stitch prefix to all temporary directory names

### DIFF
--- a/src/finn/transformation/fpgadataflow/create_stitched_ip.py
+++ b/src/finn/transformation/fpgadataflow/create_stitched_ip.py
@@ -558,7 +558,7 @@ class CreateStitchedIP(Transformation):
         prjname = "finn_vivado_stitch_proj"
         build_dir_prefix = "vivado_stitch_proj_"
         if len(model.graph.node) <= 3:
-            build_dir_prefix = "".join([node.name + "_" for node in model.graph.node])
+            build_dir_prefix += "".join([node.name + "_" for node in model.graph.node])
         vivado_stitch_proj_dir = make_build_dir(prefix=build_dir_prefix)
         model.set_metadata_prop("vivado_stitch_proj", str(vivado_stitch_proj_dir))
         # start building the tcl script


### PR DESCRIPTION
Previously, projects with less than 4 cores were just named: "CoreA_CoreB_CoreC", which could be a little confusing. This change leaves the core names but still adds the "vivado_stitch_proj" prefix for clarification.