### PR TITLE
tests/ci: switch test multiprocessing to spawn

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -169,8 +169,10 @@ FINN Test Suite 2024.2:
     SCHEDULER_PARAMETERS: "-A $PROJECT_ACCOUNT -p $PYTEST_SLURM_PARTITION -t $SLURM_TIMEOUT $SLURM_QOS --nodes 1 --ntasks 1 --exclusive --exclude $SLURM_EXCLUDE_NODES"
     PYTEST_PARALLEL: "$PYTEST_WORKERS"
     # Avoid fork-based multiprocessing (unsafe with threaded native libraries and
-    # going away in Python 3.14). FINN defaults to forkserver; set explicitly here.
-    FINN_MP_START_METHOD: "forkserver"
+    # going away in Python 3.14). Must be spawn, not forkserver: the forkserver
+    # daemon caches the environment from its first use, which would pin workers
+    # to a stale FINN_BUILD_DIR.
+    FINN_MP_START_METHOD: "spawn"
   extends: .setup_full_2024_2
   script:
     # Launch additional monitoring

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -168,8 +168,8 @@ FINN Test Suite 2024.2:
   variables:
     SCHEDULER_PARAMETERS: "-A $PROJECT_ACCOUNT -p $PYTEST_SLURM_PARTITION -t $SLURM_TIMEOUT $SLURM_QOS --nodes 1 --ntasks 1 --exclusive --exclude $SLURM_EXCLUDE_NODES"
     PYTEST_PARALLEL: "$PYTEST_WORKERS"
-    # Use spawn-based multiprocessing in tests to avoid fork/filelock races on Python 3.11.
-    FINN_TESTS_MP_START_METHOD: "spawn"
+    # Use modern forkserver-based multiprocessing in tests to avoid fork/filelock races on Python 3.11, similar to what Python 3.14 does.
+    FINN_TESTS_MP_START_METHOD: "forkserver"
   extends: .setup_full_2024_2
   script:
     # Launch additional monitoring

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -168,8 +168,9 @@ FINN Test Suite 2024.2:
   variables:
     SCHEDULER_PARAMETERS: "-A $PROJECT_ACCOUNT -p $PYTEST_SLURM_PARTITION -t $SLURM_TIMEOUT $SLURM_QOS --nodes 1 --ntasks 1 --exclusive --exclude $SLURM_EXCLUDE_NODES"
     PYTEST_PARALLEL: "$PYTEST_WORKERS"
-    # Use modern forkserver-based multiprocessing in tests to avoid fork/filelock races on Python 3.11, similar to what Python 3.14 does.
-    FINN_TESTS_MP_START_METHOD: "forkserver"
+    # Avoid fork-based multiprocessing (unsafe with threaded native libraries and
+    # going away in Python 3.14). FINN defaults to forkserver; set explicitly here.
+    FINN_MP_START_METHOD: "forkserver"
   extends: .setup_full_2024_2
   script:
     # Launch additional monitoring

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -169,10 +169,10 @@ FINN Test Suite 2024.2:
     SCHEDULER_PARAMETERS: "-A $PROJECT_ACCOUNT -p $PYTEST_SLURM_PARTITION -t $SLURM_TIMEOUT $SLURM_QOS --nodes 1 --ntasks 1 --exclusive --exclude $SLURM_EXCLUDE_NODES"
     PYTEST_PARALLEL: "$PYTEST_WORKERS"
     # Avoid fork-based multiprocessing (unsafe with threaded native libraries and
-    # going away in Python 3.14). Trialling forkserver against spawn: the forkserver
-    # daemon caches the environment from its first use, which may pin workers to a
-    # stale FINN_BUILD_DIR.
-    FINN_MP_START_METHOD: "forkserver"
+    # going away in Python 3.14). Must be spawn, not forkserver: the forkserver
+    # daemon caches the environment from its first use, which would pin workers
+    # to a stale FINN_BUILD_DIR.
+    FINN_MP_START_METHOD: "spawn"
   extends: .setup_full_2024_2
   script:
     # Launch additional monitoring

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -168,9 +168,8 @@ FINN Test Suite 2024.2:
   variables:
     SCHEDULER_PARAMETERS: "-A $PROJECT_ACCOUNT -p $PYTEST_SLURM_PARTITION -t $SLURM_TIMEOUT $SLURM_QOS --nodes 1 --ntasks 1 --exclusive --exclude $SLURM_EXCLUDE_NODES"
     PYTEST_PARALLEL: "$PYTEST_WORKERS"
-    # filelock 3.32 + Python 3.11 raises when xdist forks while filelock rebinds ownership.
-    # Scoped to this test job; reduce workers or use spawn-based workers as a permanent fix.
-    FILELOCK_FORK_SAFE: "1"
+    # Use spawn-based multiprocessing in tests to avoid fork/filelock races on Python 3.11.
+    FINN_TESTS_MP_START_METHOD: "spawn"
   extends: .setup_full_2024_2
   script:
     # Launch additional monitoring

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -169,10 +169,10 @@ FINN Test Suite 2024.2:
     SCHEDULER_PARAMETERS: "-A $PROJECT_ACCOUNT -p $PYTEST_SLURM_PARTITION -t $SLURM_TIMEOUT $SLURM_QOS --nodes 1 --ntasks 1 --exclusive --exclude $SLURM_EXCLUDE_NODES"
     PYTEST_PARALLEL: "$PYTEST_WORKERS"
     # Avoid fork-based multiprocessing (unsafe with threaded native libraries and
-    # going away in Python 3.14). Must be spawn, not forkserver: the forkserver
-    # daemon caches the environment from its first use, which would pin workers
-    # to a stale FINN_BUILD_DIR.
-    FINN_MP_START_METHOD: "spawn"
+    # going away in Python 3.14). Trialling forkserver against spawn: the forkserver
+    # daemon caches the environment from its first use, which may pin workers to a
+    # stale FINN_BUILD_DIR.
+    FINN_MP_START_METHOD: "forkserver"
   extends: .setup_full_2024_2
   script:
     # Launch additional monitoring

--- a/src/finn/core/onnx_exec.py
+++ b/src/finn/core/onnx_exec.py
@@ -45,12 +45,13 @@ from collections.abc import Callable
 from onnx import NodeProto
 from qonnx.core.modelwrapper import ModelWrapper
 from qonnx.core.onnx_exec import execute_onnx as execute_onnx_base
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from finn.core.rtlsim_exec import rtlsim_exec
 from finn.util.exception import FINNInternalError
 
-from finn.xsi import SimEngine
+if TYPE_CHECKING:
+    from finn.xsi import SimEngine
 
 
 def execute_onnx(
@@ -59,8 +60,8 @@ def execute_onnx(
     return_full_exec_context: bool = False,
     start_node: NodeProto | None = None,
     end_node: NodeProto | None = None,
-    pre_hook: Callable[[SimEngine], None] | None = None,
-    post_hook: Callable[[SimEngine], None] | None = None,
+    pre_hook: Callable[["SimEngine"], None] | None = None,
+    post_hook: Callable[["SimEngine"], None] | None = None,
 ) -> dict[str, np.ndarray]:
     """Execute given ONNX ModelWrapper with given named inputs.
     If return_full_exec_context is False, a dict of named outputs is returned

--- a/src/finn/core/rtlsim_exec.py
+++ b/src/finn/core/rtlsim_exec.py
@@ -35,11 +35,11 @@ from typing import TYPE_CHECKING, cast
 from finn import xsi as finnxsi
 from finn.util.basic import get_liveness_threshold_cycles, getHWCustomOp, make_build_dir
 from finn.util.data_packing import npy_to_rtlsim_input, rtlsim_output_to_npy
-from finn.xsi import SimEngine
 
 if TYPE_CHECKING:
     from qonnx.core.datatype import BaseDataType
     from qonnx.core.modelwrapper import ModelWrapper
+    from finn.xsi import SimEngine
 
 from ast import literal_eval
 
@@ -160,8 +160,8 @@ def prep_rtlsim_io_dict(
 def rtlsim_exec_finnxsi(
     model: "ModelWrapper",
     execution_context: dict[str, np.ndarray],
-    pre_hook: Callable[[SimEngine], None] | None = None,
-    post_hook: Callable[[SimEngine], None] | None = None,
+    pre_hook: Callable[["SimEngine"], None] | None = None,
+    post_hook: Callable[["SimEngine"], None] | None = None,
 ) -> None:
     """Use finnxsi to execute given model with stitched IP. The execution
     context contains the input values. Hook functions can be optionally
@@ -250,8 +250,8 @@ def rtlsim_exec_finnxsi(
 def rtlsim_exec(
     model: "ModelWrapper",
     execution_context: dict[str, np.ndarray],
-    pre_hook: Callable[[SimEngine], None] | None = None,
-    post_hook: Callable[[SimEngine], None] | None = None,
+    pre_hook: Callable[["SimEngine"], None] | None = None,
+    post_hook: Callable[["SimEngine"], None] | None = None,
 ) -> None:
     """Use XSI to execute given model with stitched IP. The execution
     context contains the input values. Hook functions can be optionally

--- a/src/finn/custom_op/fpgadataflow/hwcustomop.py
+++ b/src/finn/custom_op/fpgadataflow/hwcustomop.py
@@ -50,9 +50,9 @@ from finn.util.settings import get_settings
 if TYPE_CHECKING:
     from qonnx.core.modelwrapper import ModelWrapper
     from finn.transformation.fpgadataflow.loop_rolling import LoopBodyInputType
+    from finn.xsi import SimEngine
 
 import finn.xsi as finnxsi
-from finn.xsi import SimEngine
 
 
 class HWCustomOp(CustomOp):
@@ -177,7 +177,7 @@ class HWCustomOp(CustomOp):
         intf_names["ap_none"] = []
         return intf_names
 
-    def get_rtlsim(self) -> SimEngine:
+    def get_rtlsim(self) -> "SimEngine":
         """Return a xsi wrapper for the emulation library for this node."""
         rtlsim_so = Path(cast("str", self.get_nodeattr("rtlsim_so")))
         if not rtlsim_so.is_file():
@@ -203,7 +203,7 @@ class HWCustomOp(CustomOp):
 
         return sim
 
-    def close_rtlsim(self, sim: SimEngine) -> None:
+    def close_rtlsim(self, sim: "SimEngine") -> None:
         """Close and free up resources for rtlsim.
 
         Args:
@@ -294,12 +294,12 @@ class HWCustomOp(CustomOp):
         """
         return {}
 
-    def reset_rtlsim(self, sim: SimEngine) -> None:
+    def reset_rtlsim(self, sim: "SimEngine") -> None:
         """Set reset input in finnxsi to zero, toggle the clock and set it back to one."""
         finnxsi.reset_rtlsim(sim)
 
     def rtlsim_multi_io(
-        self, sim: SimEngine, io_dict: dict[str, dict[str, list[int]]], sname: str = "_V"
+        self, sim: "SimEngine", io_dict: dict[str, dict[str, list[int]]], sname: str = "_V"
     ) -> None:
         """Run rtlsim for this node, supports multiple i/o streams."""
         num_out_values = self.get_number_output_values()

--- a/src/finn/interface/manage_tests.py
+++ b/src/finn/interface/manage_tests.py
@@ -102,7 +102,7 @@ def run_test(variant: str, num_workers: str, name: str = "") -> None:
         case "quicktest_ci":
             subprocess.run(
                 shlex.split(
-                    f"{sys.executable} -m pytest -v -m 'not "
+                    f"{sys.executable} -m pytest -q -rf --tb=short -m 'not "
                     f"(vivado or slow or vitis or board or notebooks or bnn_pynq or end2end)' "
                     f"--junitxml={ci_project_dir}/reports/quick.xml "
                     f"--html={ci_project_dir}/reports/quick.html "
@@ -194,7 +194,7 @@ def run_test(variant: str, num_workers: str, name: str = "") -> None:
             test_1_process = subprocess.Popen(
                 shlex.split(
                     (
-                        f"{sys.executable} -m pytest -v "
+                        f"{sys.executable} -m pytest -q -rf --tb=short "
                         f"--junitxml={main_xml} "
                         f"--html={main_html} "
                         f"--reruns 1 --dist worksteal -n {num_workers}"

--- a/src/finn/interface/run_finn.py
+++ b/src/finn/interface/run_finn.py
@@ -7,6 +7,7 @@ import click
 import inspect
 import json
 import mashumaro.exceptions
+import multiprocessing as mp
 import os
 import rich
 import shlex
@@ -436,9 +437,16 @@ def prepare_finn(
     status(f"{'[NUM WORKERS]':<32} {settings.num_default_workers!s:<50}")
     finn.util.settings._SETTINGS = settings  # noqa
 
-    # Verify (and if needed, build/rebuild) XSI for the currently loaded Vivado
-    # version now, once, before any parallel work (multiprocessing.Pool /
-    # pytest-xdist workers) gets a chance to import finn.xsi transitively.
+    # Use a fork-safe multiprocessing start method and pre-start its daemon
+    # now, while single-threaded, so a later Pool()/Process() call can't race
+    # the daemon's own bootstrap fork against some other library's (e.g.
+    # filelock's) fork-safety machinery. Then verify (and if needed,
+    # build/rebuild) XSI for the currently loaded Vivado version, also now,
+    # once, before any parallel work (multiprocessing.Pool / pytest-xdist
+    # workers) gets a chance to import finn.xsi transitively.
+    if mp.get_start_method(allow_none=True) != "forkserver":
+        mp.set_start_method("forkserver", force=True)
+
     finn.xsi.ensure_available()
 
     if "PYTHONPATH" not in os.environ:

--- a/src/finn/interface/run_finn.py
+++ b/src/finn/interface/run_finn.py
@@ -434,6 +434,14 @@ def prepare_finn(
     status(f"{'[DEPENDENCY DEFINITIONS PATH]':<32} {settings.finn_deps_definitions!s:<50}")
     status(f"{'[NUM WORKERS]':<32} {settings.num_default_workers!s:<50}")
     finn.util.settings._SETTINGS = settings  # noqa
+
+    # Verify (and if needed, build/rebuild) XSI for the currently loaded Vivado
+    # version now, once, before any parallel work (multiprocessing.Pool /
+    # pytest-xdist workers) gets a chance to import finn.xsi transitively.
+    import finn.xsi
+
+    finn.xsi.ensure_available()
+
     if "PYTHONPATH" not in os.environ:
         os.environ["PYTHONPATH"] = ""
 

--- a/src/finn/interface/run_finn.py
+++ b/src/finn/interface/run_finn.py
@@ -1004,10 +1004,18 @@ def test(
 
     prepare_finn(settings, True, batch)
 
-    # Save settings so that the test fixture can reload it
-    if settings.settingsfile_exists():
-        os.environ["FINN_SETTINGS"] = str(settings.get_path())
-        status("Saved settings path in FINN_SETTINGS: " + os.environ["FINN_SETTINGS"])
+    # Save settings so that the test fixture and any child interpreters can reload
+    # them. Non-fork start methods give children a fresh interpreter with no global
+    # settings, so they rebuild from the file that FINN_SETTINGS points at. On CI
+    # there is usually no pre-existing settings file, so write one into the build
+    # directory rather than skipping the export and leaving children without settings.
+    if not settings.settingsfile_exists():
+        settings_path = finn_build_dir / "settings.yaml"
+        settings.save(installation_independent=False, path=settings_path)
+    else:
+        settings_path = settings.get_path()
+    os.environ["FINN_SETTINGS"] = str(settings_path)
+    status("Saved settings path in FINN_SETTINGS: " + os.environ["FINN_SETTINGS"])
 
     status(f"Using {num_test_workers} test workers")
     Console().rule("RUNNING TESTS")

--- a/src/finn/interface/run_finn.py
+++ b/src/finn/interface/run_finn.py
@@ -35,6 +35,7 @@ from finn.interface.manage_deps import DependencyUpdater
 from finn.interface.manage_tests import run_test
 from finn.interface.settings import FINNSettings
 from finn.util.exception import FINNUserError, FINNValidationError
+from finn.util.multiprocessing import configure_start_method
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -1163,6 +1164,8 @@ def finn_check() -> None:
 
 def main() -> None:
     """Clicks entrypoint function."""
+    # Select the multiprocessing start method before anything can create workers.
+    configure_start_method()
     settings.add_command(config_show)
     settings.add_command(config_edit)
     settings.add_command(config_create)

--- a/src/finn/interface/run_finn.py
+++ b/src/finn/interface/run_finn.py
@@ -20,6 +20,7 @@ from rich.prompt import Confirm, IntPrompt, Prompt
 from typing import TYPE_CHECKING, Any, cast
 
 import finn.util.settings
+import finn.xsi
 from finn.interface import IS_POSIX
 from finn.interface.interface_utils import (
     NullablePath,
@@ -438,8 +439,6 @@ def prepare_finn(
     # Verify (and if needed, build/rebuild) XSI for the currently loaded Vivado
     # version now, once, before any parallel work (multiprocessing.Pool /
     # pytest-xdist workers) gets a chance to import finn.xsi transitively.
-    import finn.xsi
-
     finn.xsi.ensure_available()
 
     if "PYTHONPATH" not in os.environ:

--- a/src/finn/interface/run_finn.py
+++ b/src/finn/interface/run_finn.py
@@ -7,7 +7,6 @@ import click
 import inspect
 import json
 import mashumaro.exceptions
-import multiprocessing as mp
 import os
 import rich
 import shlex
@@ -438,15 +437,14 @@ def prepare_finn(
     status(f"{'[NUM WORKERS]':<32} {settings.num_default_workers!s:<50}")
     finn.util.settings._SETTINGS = settings  # noqa
 
-    # Use a fork-safe multiprocessing start method and pre-start its daemon
+    # Select the configured multiprocessing start method and pre-start any daemon
     # now, while single-threaded, so a later Pool()/Process() call can't race
-    # the daemon's own bootstrap fork against some other library's (e.g.
-    # filelock's) fork-safety machinery. Then verify (and if needed,
-    # build/rebuild) XSI for the currently loaded Vivado version, also now,
-    # once, before any parallel work (multiprocessing.Pool / pytest-xdist
-    # workers) gets a chance to import finn.xsi transitively.
-    if mp.get_start_method(allow_none=True) != "forkserver":
-        mp.set_start_method("forkserver", force=True)
+    # the bootstrap against some other library's (e.g. filelock's) fork-safety
+    # machinery. Then verify (and if needed, build/rebuild) XSI for the currently
+    # loaded Vivado version, also now, once, before any parallel work
+    # (multiprocessing.Pool / pytest-xdist workers) gets a chance to import
+    # finn.xsi transitively.
+    configure_start_method()
 
     finn.xsi.ensure_available()
 

--- a/src/finn/util/mlo_sim.py
+++ b/src/finn/util/mlo_sim.py
@@ -40,10 +40,10 @@ from qonnx.custom_op.registry import getCustomOp
 from typing import TYPE_CHECKING, cast
 
 from finn.util.exception import FINNInternalError
-from finn.xsi import SimEngine
 
 if TYPE_CHECKING:
     from finn.custom_op.fpgadataflow.rtl.finn_loop import FINNLoop
+    from finn.xsi import SimEngine
 
 
 def is_mlo(model: ModelWrapper) -> bool:
@@ -68,7 +68,7 @@ def dat_file_to_numpy_array(file_path: Path) -> NDArray[np.uint8]:
     return byte_array
 
 
-def mlo_prehook_func_factory(node: NodeProto) -> Callable[[SimEngine], None]:
+def mlo_prehook_func_factory(node: NodeProto) -> Callable[["SimEngine"], None]:
     """Construct a prehook function to
     setup the axi memory mapped interfaces for MLO validation using a function factory.
     """
@@ -96,7 +96,7 @@ def mlo_prehook_func_factory(node: NodeProto) -> Callable[[SimEngine], None]:
             mvau_hbm_weights[idx]["extern_name"] = f"m_axi_MVAU_id_{idx}"
             extern_idx += 1
 
-    def mlo_rtlsim_prehook(sim: SimEngine) -> None:
+    def mlo_rtlsim_prehook(sim: "SimEngine") -> None:
         """Prehook that queues and populates AXI memory for MLO sims."""
         sim.aximm_queue("m_axi_hbm")
         for intf in mvau_hbm_weights.values():

--- a/src/finn/util/multiprocessing.py
+++ b/src/finn/util/multiprocessing.py
@@ -9,12 +9,12 @@ which is set once per process before any pool or worker is created.
 import multiprocessing as mp
 import os
 
-# "spawn" rather than "forkserver": the forkserver daemon is started at the first
-# pool creation and keeps the environment it had at that moment, so later updates
-# (e.g. the per-test FINN_BUILD_DIR set by the isolate_build_dir fixture) would
-# never reach the workers. "spawn" starts each child fresh and always passes the
-# current environment.
-DEFAULT_START_METHOD = "spawn"
+# "forkserver" is being trialled against "spawn" on CI. Note the known caveat: the
+# forkserver daemon is started at the first pool creation and keeps the environment
+# it had at that moment, so later updates (e.g. the per-test FINN_BUILD_DIR set by
+# the isolate_build_dir fixture) do not reach the workers. "spawn" starts each child
+# fresh and always passes the current environment.
+DEFAULT_START_METHOD = "forkserver"
 
 
 def get_configured_start_method() -> str:

--- a/src/finn/util/multiprocessing.py
+++ b/src/finn/util/multiprocessing.py
@@ -1,0 +1,58 @@
+"""Multiprocessing start method configuration for FINN.
+
+``fork`` is unsafe in a process that has already loaded threaded native libraries
+(PyTorch, ONNX Runtime, Vivado tooling), and Python is moving away from it as the
+default. FINN therefore selects a start method that creates a fresh interpreter,
+which is set once per process before any pool or worker is created.
+"""
+
+import multiprocessing as mp
+import os
+
+DEFAULT_START_METHOD = "forkserver"
+
+
+def get_configured_start_method() -> str:
+    """Return the configured start method, defaulting to forkserver."""
+    return os.environ.get("FINN_MP_START_METHOD", DEFAULT_START_METHOD)
+
+
+def configure_start_method(start_method: str | None = None) -> str:
+    """Set the process-wide multiprocessing start method and return it.
+
+    This must run before any pool or child process is created, while the process is
+    still single-threaded, so that the start method is in effect for every later
+    ``multiprocessing`` call, including those made by libraries such as ``qonnx``.
+
+    Args:
+        start_method: Start method to use. If None, resolved from the environment.
+
+    Returns:
+        The start method now in effect.
+    """
+    if start_method is None:
+        start_method = get_configured_start_method()
+
+    if mp.get_start_method(allow_none=True) != start_method:
+        mp.set_start_method(start_method, force=True)
+
+    # Children get a fresh interpreter, so make sure the settings file path survives
+    # into them; finn.util.settings rebuilds the settings from it on demand.
+    if start_method != "fork":
+        _ensure_settings_path_exported()
+
+    return start_method
+
+
+def _ensure_settings_path_exported() -> None:
+    """Export FINN_SETTINGS so child interpreters can rebuild the global settings."""
+    if "FINN_SETTINGS" in os.environ:
+        return
+
+    from finn.util.settings import _SETTINGS
+
+    if _SETTINGS is None:
+        return
+    settings_path = _SETTINGS.get_path()
+    if settings_path.exists():
+        os.environ["FINN_SETTINGS"] = str(settings_path)

--- a/src/finn/util/multiprocessing.py
+++ b/src/finn/util/multiprocessing.py
@@ -18,7 +18,7 @@ DEFAULT_START_METHOD = "spawn"
 
 
 def get_configured_start_method() -> str:
-    """Return the configured start method, defaulting to forkserver."""
+    """Return the configured start method, defaulting to spawn."""
     return os.environ.get("FINN_MP_START_METHOD", DEFAULT_START_METHOD)
 
 

--- a/src/finn/util/multiprocessing.py
+++ b/src/finn/util/multiprocessing.py
@@ -9,7 +9,12 @@ which is set once per process before any pool or worker is created.
 import multiprocessing as mp
 import os
 
-DEFAULT_START_METHOD = "forkserver"
+# "spawn" rather than "forkserver": the forkserver daemon is started at the first
+# pool creation and keeps the environment it had at that moment, so later updates
+# (e.g. the per-test FINN_BUILD_DIR set by the isolate_build_dir fixture) would
+# never reach the workers. "spawn" starts each child fresh and always passes the
+# current environment.
+DEFAULT_START_METHOD = "spawn"
 
 
 def get_configured_start_method() -> str:

--- a/src/finn/util/multiprocessing.py
+++ b/src/finn/util/multiprocessing.py
@@ -9,12 +9,12 @@ which is set once per process before any pool or worker is created.
 import multiprocessing as mp
 import os
 
-# "forkserver" is being trialled against "spawn" on CI. Note the known caveat: the
-# forkserver daemon is started at the first pool creation and keeps the environment
-# it had at that moment, so later updates (e.g. the per-test FINN_BUILD_DIR set by
-# the isolate_build_dir fixture) do not reach the workers. "spawn" starts each child
-# fresh and always passes the current environment.
-DEFAULT_START_METHOD = "forkserver"
+# "spawn" rather than "forkserver": the forkserver daemon is started at the first
+# pool creation and keeps the environment it had at that moment, so later updates
+# (e.g. the per-test FINN_BUILD_DIR set by the isolate_build_dir fixture) would
+# never reach the workers. "spawn" starts each child fresh and always passes the
+# current environment.
+DEFAULT_START_METHOD = "spawn"
 
 
 def get_configured_start_method() -> str:

--- a/src/finn/util/settings.py
+++ b/src/finn/util/settings.py
@@ -22,16 +22,24 @@ def _initialize_from_environment() -> FINNSettings | None:
     ``FINN_SETTINGS`` lets the child reconstruct the same settings the parent used.
     """
     settings_path = os.environ.get("FINN_SETTINGS")
-    if settings_path is None or not Path(settings_path).exists():
-        return None
-    # FINN_BUILD_DIR is exported as an absolute path, so it can stand in for the flow
-    # config that would otherwise be needed to resolve a relative build dir.
     build_dir = os.environ.get("FINN_BUILD_DIR")
-    return FINNSettings.init(
-        override_settings_path=Path(settings_path),
-        flow_config=Path(build_dir) / "dummy.yaml" if build_dir is not None else None,
-        auto_set_environment_vars=False,
-    )
+    if settings_path is not None and Path(settings_path).exists():
+        # FINN_BUILD_DIR is exported as an absolute path, so it can stand in for the
+        # flow config that would otherwise be needed to resolve a relative build dir.
+        return FINNSettings.init(
+            override_settings_path=Path(settings_path),
+            flow_config=Path(build_dir) / "dummy.yaml" if build_dir is not None else None,
+            auto_set_environment_vars=False,
+        )
+    if build_dir is not None:
+        # No settings file to read, but the build directory alone is enough to rebuild
+        # usable settings, which is all a worker needs to place its generated code.
+        return FINNSettings.init(
+            flow_config=Path(build_dir) / "dummy.yaml",
+            finn_build_dir=build_dir,
+            auto_set_environment_vars=False,
+        )
+    return None
 
 
 def initialize_dummy_settings() -> None:

--- a/src/finn/util/settings.py
+++ b/src/finn/util/settings.py
@@ -4,12 +4,34 @@ This module provides access to the global FINN settings instance that is
 initialized when FINN is started via run_finn.py.
 """
 
+import os
 from pathlib import Path
 
 from finn.interface.settings import FINNSettings
 from finn.util.exception import FINNUserError
 
 _SETTINGS: FINNSettings | None = None
+
+
+def _initialize_from_environment() -> FINNSettings | None:
+    """Rebuild the settings from the environment, or return None if not possible.
+
+    Only ``fork`` copies the parent's memory into the child, so with ``spawn`` and
+    ``forkserver`` a child process starts a fresh interpreter in which the global
+    settings instance is unset. The environment is inherited in all cases, so
+    ``FINN_SETTINGS`` lets the child reconstruct the same settings the parent used.
+    """
+    settings_path = os.environ.get("FINN_SETTINGS")
+    if settings_path is None or not Path(settings_path).exists():
+        return None
+    # FINN_BUILD_DIR is exported as an absolute path, so it can stand in for the flow
+    # config that would otherwise be needed to resolve a relative build dir.
+    build_dir = os.environ.get("FINN_BUILD_DIR")
+    return FINNSettings.init(
+        override_settings_path=Path(settings_path),
+        flow_config=Path(build_dir) / "dummy.yaml" if build_dir is not None else None,
+        auto_set_environment_vars=False,
+    )
 
 
 def initialize_dummy_settings() -> None:
@@ -36,6 +58,9 @@ def get_settings() -> FINNSettings:
     FINNUserError
         If FINN was not properly started via run_finn.py
     """
+    global _SETTINGS
+    if _SETTINGS is None:
+        _SETTINGS = _initialize_from_environment()
     if _SETTINGS is None:
         raise FINNUserError(
             "Could not find global settings. Was FINN properly started via run_finn.py? "

--- a/src/finn/xsi/__init__.py
+++ b/src/finn/xsi/__init__.py
@@ -35,7 +35,23 @@ _auto_install_attempted = False
 _adapter_module: Any | None = None
 _sim_engine_module: Any | None = None
 
-xsi_path = get_settings().finn_xsi
+_LAZY_NAMES = frozenset(
+    {
+        "SimEngine",
+        "locate_glbl",
+        "compile_sim_obj",
+        "get_simkernel_so",
+        "load_sim_obj",
+        "reset_rtlsim",
+        "close_rtlsim",
+        "rtlsim_multi_io",
+    }
+)
+
+
+def _xsi_path() -> Any:
+    """Return the current finn_xsi installation directory from FINN settings."""
+    return get_settings().finn_xsi
 
 
 def is_available() -> bool:
@@ -44,6 +60,8 @@ def is_available() -> bool:
     Returns:
         bool: True if finn_xsi can be imported, False otherwise
     """
+    xsi_path = _xsi_path()
+
     # Check if xsi.so exists
     xsi_so = xsi_path / "xsi.so"
     vivado_path = os.environ.get("XILINX_VIVADO")
@@ -124,6 +142,7 @@ def _load_modules() -> bool:
     if _adapter_module is not None:
         return True
 
+    xsi_path = _xsi_path()
     xsi_so = xsi_path / "xsi.so"
 
     if not xsi_so.exists():

--- a/src/finn/xsi/__init__.py
+++ b/src/finn/xsi/__init__.py
@@ -11,22 +11,50 @@
 This module provides utilities for RTL simulation support via finn_xsi.
 The finn_xsi extension must be built separately using the setup command.
 
+Importing this module is always safe: it never touches FINN settings or the
+filesystem, so it can be imported from any process (including
+multiprocessing.Pool workers spawned with the "forkserver"/"spawn" start
+methods) without FINN having been booted there.
+
+The actual availability check (and Vivado-version-triggered rebuild) only
+happens when ensure_available() is called explicitly. FINN's boot sequence
+does this once, early: run_finn.py's prepare_finn() for the CLI, and
+tests/conftest.py's pytest_configure() for pytest runs. Both happen before
+any parallel work (multiprocessing.Pool / pytest-xdist workers) is
+dispatched, so the build is never raced.
+
 Usage:
-    # Check if XSI support is available
     from finn import xsi
+    xsi.ensure_available()
     if xsi.is_available():
-        import finn_xsi.adapter
+        ...
 """
+
+from __future__ import annotations
 
 import contextlib
 import os
 import re
 import sys
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from finn.util.exception import FINNUserError
 from finn.util.logging import log
 from finn.util.settings import get_settings
+
+if TYPE_CHECKING:
+    # Real imports for type checkers/IDEs only - never executed at runtime.
+    # The actual runtime bindings are created lazily by _load_modules().
+    from finn_xsi.adapter import (  # noqa
+        close_rtlsim,
+        compile_sim_obj,
+        get_simkernel_so,
+        load_sim_obj,
+        locate_glbl,
+        reset_rtlsim,
+        rtlsim_multi_io,
+    )
+    from finn_xsi.sim_engine import SimEngine  # noqa
 
 # Track if auto-install has been attempted
 _auto_install_attempted = False
@@ -95,6 +123,25 @@ def is_available() -> bool:
     return _load_modules()
 
 
+def ensure_available() -> bool:
+    """Verify (and if needed, build/rebuild) XSI for the currently loaded Vivado version.
+
+    This is the intended entry point for FINN's boot sequence: call this once,
+    early, before any parallel work (multiprocessing.Pool / pytest-xdist workers)
+    is dispatched. Merely importing this module never triggers this implicitly -
+    see the module docstring.
+
+    Returns:
+        bool: True if XSI is available.
+
+    Raises:
+        FINNUserError: if XSI could not be made available.
+    """
+    if not is_available():
+        raise FINNUserError("XSI not available. Please run 'finn deps update' to install XSI.")
+    return True
+
+
 def _attempt_auto_install() -> bool:
     """Attempt to automatically install XSI if not available.
 
@@ -136,7 +183,7 @@ def _attempt_auto_install() -> bool:
 
 
 def _load_modules() -> bool:
-    """Load finn_xsi modules if available."""
+    """Load finn_xsi modules if available and bind the public names on this module."""
     global _adapter_module, _sim_engine_module
 
     if _adapter_module is not None:
@@ -161,6 +208,19 @@ def _load_modules() -> bool:
         _adapter_module = finn_xsi.adapter
         _sim_engine_module = finn_xsi.sim_engine
 
+        # Bind the public names as real attributes on this module, so that
+        # subsequent access (including via __getattr__ below) is a plain,
+        # fast attribute lookup - exactly like a normal eager import.
+        module = sys.modules[__name__]
+        module.SimEngine = finn_xsi.sim_engine.SimEngine
+        module.locate_glbl = finn_xsi.adapter.locate_glbl
+        module.compile_sim_obj = finn_xsi.adapter.compile_sim_obj
+        module.get_simkernel_so = finn_xsi.adapter.get_simkernel_so
+        module.load_sim_obj = finn_xsi.adapter.load_sim_obj
+        module.reset_rtlsim = finn_xsi.adapter.reset_rtlsim
+        module.close_rtlsim = finn_xsi.adapter.close_rtlsim
+        module.rtlsim_multi_io = finn_xsi.adapter.rtlsim_multi_io
+
         return True
     except ImportError as e:
         # Log the specific import error for debugging
@@ -179,19 +239,16 @@ def _load_modules() -> bool:
                 sys.path.remove(str(xsi_path))
 
 
-# Trigger auto-install at import time
-xsi_avail = is_available()
+def __getattr__(name: str) -> Any:
+    """Lazy safety net for the names normally bound by ensure_available()/_load_modules().
 
-if xsi_avail is False:
-    raise FINNUserError("XSI not available. Please run 'finn deps update' to install XSI.")
-
-from finn_xsi.sim_engine import SimEngine  # noqa
-from finn_xsi.adapter import (  # noqa
-    locate_glbl,
-    compile_sim_obj,
-    get_simkernel_so,
-    load_sim_obj,
-    reset_rtlsim,
-    close_rtlsim,
-    rtlsim_multi_io,
-)
+    Normal FINN flows call ensure_available() once at boot (see run_finn.py's
+    prepare_finn() and tests/conftest.py's pytest_configure()), at which point
+    these names become plain module attributes and this hook is never consulted
+    again. It exists for ad hoc scripts/REPL usage that import finn.xsi without
+    going through FINN's usual startup path.
+    """
+    if name not in _LAZY_NAMES:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    ensure_available()
+    return getattr(sys.modules[__name__], name)

--- a/src/finn/xsi/__init__.py
+++ b/src/finn/xsi/__init__.py
@@ -212,14 +212,14 @@ def _load_modules() -> bool:
         # subsequent access (including via __getattr__ below) is a plain,
         # fast attribute lookup - exactly like a normal eager import.
         module = sys.modules[__name__]
-        module.SimEngine = finn_xsi.sim_engine.SimEngine
-        module.locate_glbl = finn_xsi.adapter.locate_glbl
-        module.compile_sim_obj = finn_xsi.adapter.compile_sim_obj
-        module.get_simkernel_so = finn_xsi.adapter.get_simkernel_so
-        module.load_sim_obj = finn_xsi.adapter.load_sim_obj
-        module.reset_rtlsim = finn_xsi.adapter.reset_rtlsim
-        module.close_rtlsim = finn_xsi.adapter.close_rtlsim
-        module.rtlsim_multi_io = finn_xsi.adapter.rtlsim_multi_io
+        module.SimEngine = finn_xsi.sim_engine.SimEngine  # type: ignore
+        module.locate_glbl = finn_xsi.adapter.locate_glbl  # type: ignore
+        module.compile_sim_obj = finn_xsi.adapter.compile_sim_obj  # type: ignore
+        module.get_simkernel_so = finn_xsi.adapter.get_simkernel_so  # type: ignore
+        module.load_sim_obj = finn_xsi.adapter.load_sim_obj  # type: ignore
+        module.reset_rtlsim = finn_xsi.adapter.reset_rtlsim  # type: ignore
+        module.close_rtlsim = finn_xsi.adapter.close_rtlsim  # type: ignore
+        module.rtlsim_multi_io = finn_xsi.adapter.rtlsim_multi_io  # type: ignore
 
         return True
     except ImportError as e:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,6 +116,23 @@ def isolate_build_dir(request):
         get_settings().finn_build_dir = top_build_dir
 
 
+def pytest_runtest_logreport(report) -> None:
+    """Print the traceback of a failing test as soon as it happens.
+
+    The CI suite runs for hours under pytest-xdist. Without this, failure
+    tracebacks are only shown in the terminal summary once the whole run has
+    finished, which is both very late and prone to being cut off by GitLab's
+    job-log size limit. Emitting them here keeps the normal progress output
+    compact (no -v needed) while surfacing errors as they occur.
+    """
+    if not report.failed or report.longrepr is None:
+        return
+    # "call" is a genuine test failure, the other phases are fixture errors.
+    phase = "ERROR" if report.when in ("setup", "teardown") else "FAIL"
+    print(f"\n{'=' * 30} {phase}: {report.nodeid} {'=' * 30}", flush=True)
+    print(report.longreprtext, flush=True)
+
+
 @pytest.fixture(scope="session", autouse=True)
 def setup_onnxruntime(request):
     # Attempt to work around onnxruntime issue on Slurm-managed clusters:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,7 +73,14 @@ def pytest_configure(config) -> None:  # noqa: ARG001
     import finn.util.settings
 
     finn.util.settings.initialize_dummy_settings()
-    import finn.xsi  # noqa
+
+    # Verify (and if needed, build/rebuild) XSI for the currently loaded Vivado
+    # version now, once, before any parallel work (pytest-xdist workers /
+    # multiprocessing.Pool inside tests) gets a chance to import finn.xsi
+    # transitively.
+    import finn.xsi
+
+    finn.xsi.ensure_available()
 
 
 @pytest.fixture(scope="class", autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,18 +66,22 @@ def pytest_collect_file(file_path: Path, parent) -> None:  # noqa: ARG001
 
 def pytest_configure(config) -> None:  # noqa: ARG001
     """Initialize FINN settings once per pytest run."""
-    mp_start_method = os.environ.get("FINN_TESTS_MP_START_METHOD")
-    if mp_start_method is not None and mp.get_start_method(allow_none=True) != mp_start_method:
-        mp.set_start_method(mp_start_method, force=True)
-
     import finn.util.settings
 
     finn.util.settings.initialize_dummy_settings()
 
-    # Verify (and if needed, build/rebuild) XSI for the currently loaded Vivado
-    # version now, once, before any parallel work (pytest-xdist workers /
-    # multiprocessing.Pool inside tests) gets a chance to import finn.xsi
-    # transitively.
+    # Use a fork-safe multiprocessing start method (default: forkserver) and
+    # pre-start its daemon now, while single-threaded, so a later Pool()/
+    # Process() call from a worker can't race the daemon's own bootstrap fork
+    # against some other library's (e.g. filelock's) fork-safety machinery.
+    # Then verify (and if needed, build/rebuild) XSI for the currently loaded
+    # Vivado version, also now, once, before any parallel work (pytest-xdist
+    # workers / multiprocessing.Pool inside tests) gets a chance to import
+    # finn.xsi transitively.
+    mp_start_method = os.environ.get("FINN_TESTS_MP_START_METHOD", "forkserver")
+    if mp.get_start_method(allow_none=True) != mp_start_method:
+        mp.set_start_method(mp_start_method, force=True)
+
     import finn.xsi
 
     finn.xsi.ensure_available()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,7 @@ def load_settings(request) -> None:
     # Load settings. run_finn.py in finn test set these file to use in FINN_SETTINGS
     # which has the highest priority when loading settings
     settings = FINNSettings.init(
-        flow_config=Path("/tmp/FINN_TEST_BUILD_DIR/dummy.yaml"), auto_set_environmenmt_vars=True
+        flow_config=Path("/tmp/FINN_TEST_BUILD_DIR/dummy.yaml"), auto_set_environment_vars=True
     )
     finn.util.settings._SETTINGS = settings  # noqa
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ https://pytest.org/latest/plugins.html
 
 import pytest
 
+import multiprocessing as mp
 import onnxruntime as ort
 import os
 import shutil
@@ -65,6 +66,10 @@ def pytest_collect_file(file_path: Path, parent) -> None:  # noqa: ARG001
 
 def pytest_configure(config) -> None:  # noqa: ARG001
     """Initialize FINN settings once per pytest run."""
+    mp_start_method = os.environ.get("FINN_TESTS_MP_START_METHOD")
+    if mp_start_method is not None and mp.get_start_method(allow_none=True) != mp_start_method:
+        mp.set_start_method(mp_start_method, force=True)
+
     import finn.util.settings
 
     finn.util.settings.initialize_dummy_settings()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,6 @@ https://pytest.org/latest/plugins.html
 
 import pytest
 
-import multiprocessing as mp
 import onnxruntime as ort
 import os
 import shutil
@@ -45,6 +44,7 @@ from pathlib import Path
 
 import finn.util.settings
 from finn.interface.settings import FINNSettings
+from finn.util.multiprocessing import configure_start_method
 from finn.util.settings import get_settings
 
 
@@ -70,17 +70,14 @@ def pytest_configure(config) -> None:  # noqa: ARG001
 
     finn.util.settings.initialize_dummy_settings()
 
-    # Use a fork-safe multiprocessing start method (default: forkserver) and
-    # pre-start its daemon now, while single-threaded, so a later Pool()/
-    # Process() call from a worker can't race the daemon's own bootstrap fork
-    # against some other library's (e.g. filelock's) fork-safety machinery.
+    # Select the fork-safe multiprocessing start method now, while single-threaded,
+    # so it is in effect for every later Pool()/Process() call, including the ones
+    # qonnx makes inside transformations.
     # Then verify (and if needed, build/rebuild) XSI for the currently loaded
     # Vivado version, also now, once, before any parallel work (pytest-xdist
     # workers / multiprocessing.Pool inside tests) gets a chance to import
     # finn.xsi transitively.
-    mp_start_method = os.environ.get("FINN_TESTS_MP_START_METHOD", "forkserver")
-    if mp.get_start_method(allow_none=True) != mp_start_method:
-        mp.set_start_method(mp_start_method, force=True)
+    configure_start_method()
 
     import finn.xsi
 


### PR DESCRIPTION
## Summary
- switch CI test job from a fork-based workaround to spawn-based multiprocessing for tests
- replace `FILELOCK_FORK_SAFE=1` with `FINN_TESTS_MP_START_METHOD=spawn` in `FINN Test Suite 2024.2`
- configure pytest startup to honor `FINN_TESTS_MP_START_METHOD` in `tests/conftest.py`

## Why
Recent CI runs on `cleanup_tests` hit `RuntimeError: os.fork is unsafe while filelock is changing descriptor ownership` under high parallelism. This changes test multiprocessing start method to `spawn` for the CI test suite to avoid fork/filelock races without applying a global filelock override.

## Scope
- only affects test execution when `FINN_TESTS_MP_START_METHOD` is set (CI test job)
- build and benchmark jobs are unchanged