### PR TITLE
tests: add deterministic per-item RNG seeding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,8 @@ Please follow the steps below and be sure that your contribution complies with o
     5. Use *git add*, *git commit*, *git push* to add changes to your fork.
 
     6. If you are introducing new functionality, add at least one unit test under the `tests/` folder and make sure it passes before you submit the pull request.
+       - Tests receive a deterministic per-item `finn_test_seed` fixture from `tests/conftest.py`, and Python/NumPy/Torch RNGs are seeded automatically for each item.
+       - Avoid hard-coding global seed resets like `np.random.seed(0)` in test bodies/helpers unless a test explicitly validates seed-dependent behavior.
 
     7. Submit a pull request by clicking the *pull request* button on your GitHub repo:
         1. The [main branch](https://github.com/eki-project/finn-plus) should always be treated as stable and clean. Only hot fixes are allowed to be pull-requested. The hot fix is supposed to be very important such that without this fix, a lot of things will break.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,15 +36,48 @@ https://pytest.org/latest/plugins.html
 
 import pytest
 
+import numpy as np
 import onnxruntime as ort
 import os
+import random
 import shutil
 import tempfile
 from pathlib import Path
 
+try:
+    import torch
+except ImportError:
+    torch = None
+
 import finn.util.settings
 from finn.interface.settings import FINNSettings
 from finn.util.settings import get_settings
+from tests.rng_seed import seed_from_nodeid
+
+
+@pytest.fixture
+def finn_test_seed(request) -> int:
+    return seed_from_nodeid(request.node.nodeid)
+
+
+@pytest.fixture(autouse=True)
+def deterministic_random_state(request, finn_test_seed):
+    python_state = random.getstate()
+    numpy_state = np.random.get_state()
+    torch_state = torch.get_rng_state() if torch is not None else None
+
+    try:
+        random.seed(finn_test_seed)
+        np.random.seed(finn_test_seed)
+        if torch is not None:
+            torch.random.default_generator.manual_seed(finn_test_seed)
+        request.node.user_properties.append(("finn_test_rng_seed", str(finn_test_seed)))
+        yield
+    finally:
+        random.setstate(python_state)
+        np.random.set_state(numpy_state)
+        if torch_state is not None:
+            torch.set_rng_state(torch_state)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/fpgadataflow/test_convert_to_hw_1d_conv_layer.py
+++ b/tests/fpgadataflow/test_convert_to_hw_1d_conv_layer.py
@@ -82,7 +82,6 @@ from finn.util.fpgadataflow import is_fpgadataflow_node
 @pytest.mark.vivado
 def test_convert_to_hw_1d_conv_layer(conv_config, depthwise, use_rtl_swg, exec_mode):
     pad, kernel_size, stride, dilation = conv_config
-    np.random.seed(0)
     idt = DataType["UINT4"]
 
     in_feature_dim_h, in_feature_dim_w = [10, 1]

--- a/tests/fpgadataflow/test_convert_to_hw_conv_fc_transition.py
+++ b/tests/fpgadataflow/test_convert_to_hw_conv_fc_transition.py
@@ -64,9 +64,7 @@ from finn.transformation.streamline.reorder import MoveScalarLinearPastInvariant
 from finn.util.fpgadataflow import is_fpgadataflow_node
 
 
-def get_multithreshold_rand_params(channels, num_of_thres, seed=None):
-    if seed is not None:
-        np.random.seed(seed)
+def get_multithreshold_rand_params(channels, num_of_thres):
     steps = np.random.rand(channels, 1) * 30
     bias = np.random.rand(channels, 1) * -10
     thres = [np.arange(num_of_thres) for chn in range(channels)]
@@ -91,7 +89,6 @@ def get_multithreshold_rand_params(channels, num_of_thres, seed=None):
 @pytest.mark.vivado
 @pytest.mark.slow
 def test_convert_to_hw_conv_fc_transition(conv_config, depthwise, use_reshape):
-    np.random.seed(0)
     idt = DataType["UINT4"]
     odt = DataType["UINT4"]
     conv_weight_dt = DataType["INT4"]
@@ -181,8 +178,8 @@ def test_convert_to_hw_conv_fc_transition(conv_config, depthwise, use_reshape):
     model.set_tensor_datatype("thres2_param", DataType["INT32"])
 
     model.set_initializer("conv_param", gen_finn_dt_tensor(conv_weight_dt, conv_param_shape))
-    model.set_initializer("thres1_param", get_multithreshold_rand_params(out_chn, 15, seed=0))
-    model.set_initializer("thres2_param", get_multithreshold_rand_params(fc_filters, 15, seed=0))
+    model.set_initializer("thres1_param", get_multithreshold_rand_params(out_chn, 15))
+    model.set_initializer("thres2_param", get_multithreshold_rand_params(fc_filters, 15))
     model.set_initializer("matmul_param", gen_finn_dt_tensor(fc_weight_dt, fc_param_shape))
     model.set_initializer("reshape_shape", np.array([1, -1], dtype=np.int64))
 

--- a/tests/fpgadataflow/test_convert_to_hw_conv_layer.py
+++ b/tests/fpgadataflow/test_convert_to_hw_conv_layer.py
@@ -70,7 +70,6 @@ from finn.transformation.fpgadataflow.specialize_layers import SpecializeLayers
 @pytest.mark.vivado
 def test_convert_to_hw_conv_layer(conv_config, depthwise, exec_mode):
     kernel_size, stride, pad = conv_config
-    np.random.seed(0)
     idt = DataType["UINT4"]
 
     in_feature_dim = 7

--- a/tests/fpgadataflow/test_convert_to_hw_pool_batch.py
+++ b/tests/fpgadataflow/test_convert_to_hw_pool_batch.py
@@ -144,7 +144,6 @@ def test_convert_to_hw_pool(idt, odt, pool_config, ifm_ch, pe, op_type, exec_mod
     if pad != 0 and idt.signed():
         pytest.skip("No support for pal_val != 0. Skipping")
 
-    np.random.seed(0)
     ofm_dim = int(((ifm_dim + 2 * pad - k) / stride) + 1)
 
     ishape = (1, ifm_ch, ifm_dim, ifm_dim)

--- a/tests/fpgadataflow/test_fpgadataflow_convinputgenerator_rtl_dynamic.py
+++ b/tests/fpgadataflow/test_fpgadataflow_convinputgenerator_rtl_dynamic.py
@@ -71,8 +71,20 @@ from finn.transformation.fpgadataflow.specialize_layers import SpecializeLayers
 from finn.util.basic import get_liveness_threshold_cycles
 
 
-def create_conv_model(idim_h, idim_w, ifm, k, stride, ofm, idt, wdt, pad_mode, depthwise):
-    np.random.seed(0)
+def create_conv_model(
+    idim_h,
+    idim_w,
+    ifm,
+    k,
+    stride,
+    ofm,
+    idt,
+    wdt,
+    pad_mode,
+    depthwise,
+    c0_weight,
+    c1_weight,
+):
     group = ifm if depthwise else 1
     group_str = str(group)
     ishp = (1, ifm, idim_h, idim_w)
@@ -124,8 +136,8 @@ def create_conv_model(idim_h, idim_w, ifm, k, stride, ofm, idt, wdt, pad_mode, d
     model.set_tensor_datatype("in0", idt)
     model.set_tensor_datatype("param_c0_weight", wdt)
     model.set_tensor_datatype("param_c1_weight", wdt)
-    model.set_initializer("param_c0_weight", gen_finn_dt_tensor(wdt, wshp))
-    model.set_initializer("param_c1_weight", gen_finn_dt_tensor(wdt, wshp_1))
+    model.set_initializer("param_c0_weight", c0_weight)
+    model.set_initializer("param_c1_weight", c1_weight)
     return model
 
 
@@ -235,15 +247,29 @@ def test_fpgadataflow_conv_dynamic(cfg):
     ofm = cfg["ofm"]
     idt = DataType["UINT4"]
     wdt = DataType["INT2"]
+    wshp = (ifm, 1, k, k) if depthwise else (ofm, ifm, k, k)
+    wshp_1 = (ifm, 1, k, k) if depthwise else (ofm, ofm, k, k)
+    c0_weight = gen_finn_dt_tensor(wdt, wshp)
+    c1_weight = gen_finn_dt_tensor(wdt, wshp_1)
     exp_cfgs = []
     largest_model = None
     for idim in idims:
         idim_h, idim_w = idim
         ishp = (1, ifm, idim_h, idim_w)
-        np.random.seed(0)
         inp = gen_finn_dt_tensor(idt, ishp)
         model = create_conv_model(
-            idim_h, idim_w, ifm, k, stride, ofm, idt, wdt, pad_mode, depthwise
+            idim_h,
+            idim_w,
+            ifm,
+            k,
+            stride,
+            ofm,
+            idt,
+            wdt,
+            pad_mode,
+            depthwise,
+            c0_weight,
+            c1_weight,
         )
         _, _, int_dim_h, int_dim_w = model.get_tensor_shape("conv0")
         _, _, odim_h, odim_w = model.get_tensor_shape("out0")

--- a/tests/fpgadataflow/test_fpgadataflow_downsampler.py
+++ b/tests/fpgadataflow/test_fpgadataflow_downsampler.py
@@ -52,7 +52,6 @@ from finn.transformation.fpgadataflow.specialize_layers import SpecializeLayers
 
 
 def build_model(is_1d, in_dim, k, stride, dt_in, dt_w, pad_half=0, flip_1d=False):
-    np.random.seed(0)
     out_dim = compute_conv_output_dim(in_dim, k, stride, 2 * pad_half)
     ifm = 8
     ofm = 16

--- a/tests/fpgadataflow/test_fpgadataflow_elementwise_absdiff.py
+++ b/tests/fpgadataflow/test_fpgadataflow_elementwise_absdiff.py
@@ -62,7 +62,6 @@ from finn.transformation.fpgadataflow.specialize_layers import SpecializeLayers
 
 def build_absdiff_model(shp, dt0, dt1):
     """Build a model with Sub -> Abs pattern that will be fused to AbsDiff."""
-    np.random.seed(0)
     shp_str = str(shp)
     graph = """
     sub_out = Sub(in0, in1)

--- a/tests/fpgadataflow/test_fpgadataflow_labelselect.py
+++ b/tests/fpgadataflow/test_fpgadataflow_labelselect.py
@@ -98,7 +98,6 @@ def prepare_inputs(input_tensor, idt):
 @pytest.mark.fpgadataflow
 @pytest.mark.vivado
 def test_fpgadataflow_labelselect(idt, labels, fold, k, exec_mode, impl_style):
-    np.random.seed(0)
     if fold == -1:
         pe = 1
     else:

--- a/tests/fpgadataflow/test_fpgadataflow_requant.py
+++ b/tests/fpgadataflow/test_fpgadataflow_requant.py
@@ -378,7 +378,6 @@ def make_quant_test_model(
     else:
         q_attr_shp = (1,)
     attrshp_str = str(list(q_attr_shp))
-    np.random.seed(0)
     if need_extraction_scale:
         scale = np.random.rand(*q_attr_shp).astype(np.float32)
     else:

--- a/tests/rng_seed.py
+++ b/tests/rng_seed.py
@@ -1,0 +1,13 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import hashlib
+import re
+
+GROUP_SUFFIX_RE = re.compile(r"@[A-Za-z0-9_.-]+$")
+
+
+def seed_from_nodeid(nodeid: str) -> int:
+    canonical_nodeid = GROUP_SUFFIX_RE.sub("", nodeid)
+    digest = hashlib.sha256(canonical_nodeid.encode("utf-8")).digest()
+    return int.from_bytes(digest[:4], byteorder="big", signed=False)

--- a/tests/transformation/streamline/test_absorb_opposite_transposes.py
+++ b/tests/transformation/streamline/test_absorb_opposite_transposes.py
@@ -39,7 +39,6 @@ from finn.transformation.streamline.absorb import AbsorbConsecutiveTransposes
 
 @pytest.mark.streamline
 def test_absorb_opposite_transposes():
-    np.random.seed(0)
     shp = [1, 3, 4, 2]
     shp_str = str(shp)
     input = f"""

--- a/tests/transformation/streamline/test_collapse_repeated_op.py
+++ b/tests/transformation/streamline/test_collapse_repeated_op.py
@@ -116,7 +116,6 @@ def test_collapse_repeated_only_if_linear(test_args):
     model = ModelWrapper(modelproto)
     model = model.transform(InferShapes())
 
-    np.random.seed(0)
     model.set_initializer("p1", *np.random.rand(1).astype(np.float32))
     model.set_initializer("p2", *np.random.rand(1).astype(np.float32))
     model.set_initializer("p3", *np.random.rand(1).astype(np.float32))

--- a/tests/transformation/streamline/test_move_add_past_mul.py
+++ b/tests/transformation/streamline/test_move_add_past_mul.py
@@ -135,7 +135,6 @@ def test_move_add_past_mul_only_if_linear():
     model = ModelWrapper(modelproto)
     model = model.transform(InferShapes())
 
-    np.random.seed(0)
     model.set_initializer("add1_param", np.random.rand(2).astype(np.float32))
     model.set_initializer("mul1_param", np.random.rand(2).astype(np.float32))
     model.set_initializer("mul2_param", np.random.rand(2).astype(np.float32))

--- a/tests/transformation/streamline/test_move_maxpool_past_multithreshold.py
+++ b/tests/transformation/streamline/test_move_maxpool_past_multithreshold.py
@@ -38,9 +38,7 @@ import finn.core.onnx_exec as oxe
 from finn.transformation.streamline.reorder import MoveMaxPoolPastMultiThreshold
 
 
-def get_multithreshold_rand_params(channels, num_of_thres, seed=None):
-    if seed is not None:
-        np.random.seed(seed)
+def get_multithreshold_rand_params(channels, num_of_thres):
     steps = np.random.rand(channels, 1) * 2
     bias = np.random.rand(channels, 1) * 10
     thres = [np.arange(num_of_thres) for chn in range(channels)]
@@ -110,7 +108,7 @@ def test_move_maxpool_past_multithreshold():
     model = model.transform(InferDataTypes())
 
     model.set_initializer("thres1", np.array([[0]], dtype=np.float32))
-    model.set_initializer("thres2", get_multithreshold_rand_params(*thres2_shape, seed=0))
+    model.set_initializer("thres2", get_multithreshold_rand_params(*thres2_shape))
 
     # Transform
     new_model = model.transform(MoveMaxPoolPastMultiThreshold())

--- a/tests/transformation/streamline/test_move_past_fork.py
+++ b/tests/transformation/streamline/test_move_past_fork.py
@@ -111,7 +111,6 @@ def test_move_past_fork_linear(ch, ifmdim):
     model = ModelWrapper(model)
     model = model.transform(InferShapes())
 
-    np.random.seed(0)
     for tensor_name in model.get_all_tensor_names():
         if tensor_name.endswith("_param"):
             pshape = model.get_tensor_shape(tensor_name)

--- a/tests/transformation/streamline/test_move_scalar_past_conv.py
+++ b/tests/transformation/streamline/test_move_scalar_past_conv.py
@@ -96,7 +96,6 @@ def test_move_scalar_past_conv(test_args, padding):
     model = ModelWrapper(modelproto)
     model = model.transform(InferShapes())
 
-    np.random.seed(0)
     model.set_initializer("p1", *np.random.rand(1).astype(np.float32))
     model.set_initializer("p2", np.random.rand(*conv_param_shape).astype(np.float32))
     model.set_initializer("p3", np.random.rand(*conv_param_shape).astype(np.float32))
@@ -178,7 +177,6 @@ def test_move_scalar_past_conv_only_if_linear(test_args):
     model = ModelWrapper(modelproto)
     model = model.transform(InferShapes())
 
-    np.random.seed(0)
     model.set_initializer("p1", *np.random.rand(1).astype(np.float32))
     model.set_initializer("p2", np.random.rand(*conv_param_shape).astype(np.float32))
     model.set_initializer("p3", np.random.rand(*conv_param_shape).astype(np.float32))

--- a/tests/transformation/streamline/test_move_scalar_past_convtranspose.py
+++ b/tests/transformation/streamline/test_move_scalar_past_convtranspose.py
@@ -94,7 +94,6 @@ def test_move_scalar_past_conv(idim, stride, ifm_ch, ofm_ch, k, padding):
     model = ModelWrapper(modelproto)
     model = model.transform(InferShapes())
 
-    np.random.seed(0)
     model.set_initializer("p1", *np.random.rand(1).astype(np.float32))
     model.set_initializer("p2", np.random.rand(*conv_param_shape).astype(np.float32))
 

--- a/tests/transformation/streamline/test_move_scalar_past_matmul.py
+++ b/tests/transformation/streamline/test_move_scalar_past_matmul.py
@@ -171,7 +171,6 @@ def test_move_scalar_past_matmul_only_if_linear(test_args):
     model = ModelWrapper(modelproto)
     model = model.transform(InferShapes())
 
-    np.random.seed(0)
     model.set_initializer("p1", np.random.rand(1, 1).astype(np.float32))
     model.set_initializer("p2", np.random.rand(*matmul_shape).astype(np.float32))
     model.set_initializer("p3", np.random.rand(*matmul_shape).astype(np.float32))

--- a/tests/transformation/test_qonnx_to_finn.py
+++ b/tests/transformation/test_qonnx_to_finn.py
@@ -65,7 +65,6 @@ def get_brev_model_and_sample_inputs(model_name, wbits, abits):
         brev_model = get_test_model_trained(model_name, wbits, abits)
     elif model_name == "mobilenet":
         in_shape = (1, 3, 224, 224)
-        np.random.seed(42)
         input_tensor = np.random.normal(size=in_shape).astype(dtype=np.float32)
         brev_model = get_test_model_trained(model_name, 4, 4)
     else:

--- a/tests/util/test_rng_determinism.py
+++ b/tests/util/test_rng_determinism.py
@@ -1,0 +1,29 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+import numpy as np
+import random
+
+from tests.rng_seed import seed_from_nodeid
+
+pytestmark = pytest.mark.util
+
+
+def test_xdist_group_suffix_does_not_change_seed():
+    nodeid = "tests/sample.py::test_value[index]"
+    assert seed_from_nodeid(nodeid) == seed_from_nodeid(nodeid + "@rng_determinism")
+
+
+def test_legacy_random_state_is_derived_from_nodeid(request, finn_test_seed):
+    assert ("finn_test_rng_seed", str(finn_test_seed)) in request.node.user_properties
+    assert random.random() == random.Random(finn_test_seed).random()
+    assert np.random.rand() == np.random.RandomState(finn_test_seed).rand()
+
+
+def test_torch_random_state_is_derived_from_nodeid(finn_test_seed):
+    torch = pytest.importorskip("torch")
+    generator = torch.Generator()
+    generator.manual_seed(finn_test_seed)
+    assert torch.equal(torch.rand(4), torch.rand(4, generator=generator))


### PR DESCRIPTION
## Summary
- add deterministic per-item RNG seeding to the pytest harness via `finn_test_seed`
- seed Python `random`, `numpy.random`, and PyTorch CPU RNG automatically for each test item
- remove routine hard-coded local seed resets in fpgadataflow/transformation tests
- add RNG determinism regression tests and contributor guidance
- adapt dynamic conv-inputgenerator test setup so shared weights remain stable across shape variants

## Motivation
This makes randomized tests reproducible per pytest item while still giving distinct streams across parametrized items.

## Note
This PR was adapted from upstream inspiration: https://github.com/Xilinx/finn/pull/1645