### PR TITLE
Live FIFO-sizing improvements extracted from merge/fifo_heuristic

### DIFF
--- a/ci/cfg/live_fifosizing.yml
+++ b/ci/cfg/live_fifosizing.yml
@@ -122,16 +122,16 @@
     },
 
     # ResNet-18 (CIFAR100)
-    {
-        "dut": ["resnet18"],
-        "model_path": [models/resnet18/resnet18_w3a3_cifar100.onnx],
-        "folding_config_file": [models/resnet18/resnet18_folding_config.json],
-        "specialize_layers_config_file": [models/resnet18/resnet18_specialize_layers.json],
-        "auto_fifo_depths": [True],
-        "auto_fifo_strategy": ["live_fifo"],
-        "generate_outputs": [["bitfile", "pynq_driver", "deployment_package"]],
-        "synth_clk_period_ns": [10],
-    },
+    # {
+    #     "dut": ["resnet18"],
+    #     "model_path": [models/resnet18/resnet18_w3a3_cifar100.onnx],
+    #     "folding_config_file": [models/resnet18/resnet18_folding_config.json],
+    #     "specialize_layers_config_file": [models/resnet18/resnet18_specialize_layers.json],
+    #     "auto_fifo_depths": [True],
+    #     "auto_fifo_strategy": ["live_fifo"],
+    #     "generate_outputs": [["bitfile", "pynq_driver", "deployment_package"]],
+    #     "synth_clk_period_ns": [10],
+    # },
 
     ### NEW Transformer models (dvc-imported from finn-transformers repo):
     # benchmark model ("dummy")
@@ -154,6 +154,7 @@
         "model_path": ["models/transformer/finn-transformers/language/streamlined.onnx"],
         "verify_input_npy": ["models/transformer/finn-transformers/language/inp.npy"],
         "verify_expected_output_npy": ["models/transformer/finn-transformers/language/out.npy"],
+        "verify_steps": ["None"], # disable verification to not affect build time measurements
         "auto_fifo_depths": [True],
         "auto_fifo_strategy": ["live_fifo"],
         "generate_outputs": [["bitfile", "pynq_driver", "deployment_package"]],
@@ -167,6 +168,7 @@
         "model_path": ["models/transformer/finn-transformers/radioml/streamlined.onnx"],
         "verify_input_npy": ["models/transformer/finn-transformers/radioml/inp.npy"],
         "verify_expected_output_npy": ["models/transformer/finn-transformers/radioml/out.npy"],
+        "verify_steps": ["None"], # disable verification to not affect build time measurements
         "auto_fifo_depths": [True],
         "auto_fifo_strategy": ["live_fifo"],
         "generate_outputs": [["bitfile", "pynq_driver", "deployment_package"]],
@@ -180,6 +182,7 @@
         "model_path": ["models/transformer/finn-transformers/vision/streamlined.onnx"],
         "verify_input_npy": ["models/transformer/finn-transformers/vision/inp.npy"],
         "verify_expected_output_npy": ["models/transformer/finn-transformers/vision/out.npy"],
+        "verify_steps": ["None"], # disable verification to not affect build time measurements
         "auto_fifo_depths": [True],
         "auto_fifo_strategy": ["live_fifo"],
         "generate_outputs": [["bitfile", "pynq_driver", "deployment_package"]],

--- a/ci/collect/collect.py
+++ b/ci/collect/collect.py
@@ -1005,18 +1005,44 @@ if __name__ == "__main__":
         # Prepare benchmarking config for follow-up runs after live FIFO-sizing
         # Only generate follow-up config if this is not already a follow-up run
         if not args.followup:
-            folding_config_lfs_path = os.path.join(
+            # Choose the search order with the lowest fifo_size_total_kB
+            lfs_base_dir = os.path.join(
                 "measurement_artifacts",
                 "runs_output",
                 "run_%d" % (id),
                 "reports",
                 "experiment_fifosizing",
                 "exp_itr_1",
-                "largest_first",  # TODO: make configurable or choose best available FIFO-sizing
-                "both",
-                "folding_config_lfs.json",
             )
-            if os.path.isfile(folding_config_lfs_path):
+            best_search_order = None
+            best_fifo_size = float("inf")
+            if os.path.isdir(lfs_base_dir):
+                for search_order in os.listdir(lfs_base_dir):
+                    sizing_report_path = os.path.join(
+                        lfs_base_dir, search_order, "both", "fifo_sizing_report.json"
+                    )
+                    if os.path.isfile(sizing_report_path):
+                        with open(sizing_report_path, "r") as f:
+                            sizing_report = json.load(f)
+                        fifo_size = sizing_report.get("fifo_size_total_kB", float("inf"))
+                        if fifo_size < best_fifo_size:
+                            best_fifo_size = fifo_size
+                            best_search_order = search_order
+            if best_search_order is not None:
+                print(
+                    "Selecting search order '%s' with fifo_size_total_kB=%.2f"
+                    % (best_search_order, best_fifo_size)
+                )
+                folding_config_lfs_path = os.path.join(
+                    lfs_base_dir, best_search_order, "both", "folding_config_lfs.json"
+                )
+            else:
+                print(
+                    "No valid search order with fifo_sizing_report.json found in %s." % lfs_base_dir
+                )
+                folding_config_lfs_path = None
+
+            if folding_config_lfs_path is not None and os.path.isfile(folding_config_lfs_path):
                 print(
                     "Creating follow-up experiment config based on lfs folding config: %s"
                     % folding_config_lfs_path

--- a/finn-rtllib/fifo/hdl/fifo_template.v
+++ b/finn-rtllib/fifo/hdl/fifo_template.v
@@ -37,8 +37,13 @@ input   ap_clk,
 (* X_INTERFACE_PARAMETER = "POLARITY ACTIVE_LOW" *)
 input   ap_rst_n,
 
+`ifdef FINN_SIMULATION
+output [31:0] count,
+output [31:0] maxcount,
+`else
 output $COUNT_RANGE$ count,
 output $COUNT_RANGE$ maxcount,
+`endif
 
 //- AXI Stream - Input --------------
 output   in0_V_TREADY,
@@ -52,7 +57,7 @@ output  $OUT_RANGE$ out0_V_TDATA
 );
 
 `ifdef FINN_SIMULATION
-	fifo_gauge #(.WIDTH($WIDTH$), .COUNT_WIDTH($COUNT_WIDTH$)) fifo (
+	fifo_gauge #(.WIDTH($WIDTH$), .COUNT_WIDTH(32)) fifo (
 		.clk(ap_clk), .rst(!ap_rst_n),
 		.idat(in0_V_TDATA), .ivld(in0_V_TVALID), .irdy(in0_V_TREADY),
 		.odat(out0_V_TDATA), .ovld(out0_V_TVALID), .ordy(out0_V_TREADY),

--- a/src/finn/templates/python_driver/driver.py
+++ b/src/finn/templates/python_driver/driver.py
@@ -954,8 +954,10 @@ class FINNLiveFIFOOverlay(FINNInstrumentationOverlay):
         target_latency = latency
 
         # Apply relaxation to thresholds
+        # Always allow 0.05% latency degradation due to jitter observed for some models
+        latency_default_relaxation = 0.0005
         relaxed_interval_threshold = target_interval * (1 + relaxation)
-        relaxed_latency_threshold = target_latency * (1 + relaxation)
+        relaxed_latency_threshold = target_latency * (1 + (latency_default_relaxation + relaxation))
 
         # Binary search for each FIFO to find minimum depth
         iteration = 0
@@ -1201,7 +1203,7 @@ class FINNLiveFIFOOverlay(FINNInstrumentationOverlay):
         print("RELAXATION: %.1f%%" % (relaxation * 100))
         print("RELAXATION SWEEP: %s" % ("Enabled" if relaxation_sweep else "Disabled"))
         # Determine search iteration runtime via heuristic based on free-running latency
-        iteration_runtime = max(0.001, (paced_latency * 10) * 10 / 1000 / 1000 / 1000)
+        iteration_runtime = max(0.001, (paced_latency * 4) * 10 / 1000 / 1000 / 1000)
 
         search_log = self.size_iteratively_binary_search(
             start_depth=max_occupancy,

--- a/src/finn/transformation/fpgadataflow/make_zynq_proj.py
+++ b/src/finn/transformation/fpgadataflow/make_zynq_proj.py
@@ -31,6 +31,7 @@
 
 import json
 import math
+import multiprocessing as mp
 import os
 from pathlib import Path
 from qonnx.core.modelwrapper import ModelWrapper
@@ -38,6 +39,7 @@ from qonnx.custom_op.registry import getCustomOp
 from qonnx.transformation.base import Transformation
 from qonnx.transformation.general import GiveReadableTensorNames, GiveUniqueNodeNames
 from qonnx.transformation.infer_data_layouts import InferDataLayouts
+from qonnx.util.basic import get_num_default_workers
 from shutil import copy
 from subprocess import CalledProcessError
 from typing import Literal
@@ -59,9 +61,41 @@ from finn.util.basic import (
     pynq_part_map,
 )
 from finn.util.exception import FINNError, FINNSynthesisError
+from finn.util.logging import log
 from finn.util.settings import get_settings
 
 from . import templates
+
+
+def _build_sdp_kernel(args):
+    """Worker function for parallel SDP kernel builds.
+
+    Runs InsertFIFO (if needed), SpecializeLayers, GiveUniqueNodeNames,
+    PrepareIP, HLSSynthIP, and CreateStitchedIP for a single
+    StreamingDataflowPartition kernel. Saves the result back to disk.
+
+    Args:
+        args: tuple of (sdp_node_name, dataflow_model_filename, fpga_part,
+              period_ns, enable_instrumentation)
+    """
+    sdp_node_name, dataflow_model_filename, fpga_part, period_ns, enable_instrumentation = args
+    prefix = sdp_node_name + "_"
+    kernel_model = ModelWrapper(dataflow_model_filename)
+    # InsertFIFO at this stage interferes with tLastMarker
+    # TODO: is this really needed here at all?
+    if not enable_instrumentation:
+        kernel_model = kernel_model.transform(InsertFIFO())
+    kernel_model = kernel_model.transform(SpecializeLayers(fpga_part))
+    kernel_model = kernel_model.transform(GiveUniqueNodeNames(prefix))
+    kernel_model.save(dataflow_model_filename)
+    kernel_model = kernel_model.transform(PrepareIP(fpga_part, period_ns))
+    # Do not try to parallelize HLSSynthIP here (mp.pool within an mp.pool not allowed)
+    kernel_model = kernel_model.transform(HLSSynthIP(num_workers=1))
+    kernel_model = kernel_model.transform(
+        CreateStitchedIP(fpga_part, period_ns, sdp_node_name, False)
+    )
+    kernel_model.set_metadata_prop("platform", "zynq-iodma")
+    kernel_model.save(dataflow_model_filename)
 
 
 def collect_ip_dirs(model, ipstitch_path):
@@ -685,27 +719,29 @@ class ZynqBuild(Transformation):
             model = model.transform(trn)
             model = model.transform(GiveUniqueNodeNames())
             model = model.transform(GiveReadableTensorNames())
-        # Build each kernel individually
+        # Build each kernel individually (in parallel)
         sdp_nodes = model.get_nodes_by_op_type("StreamingDataflowPartition")
-        for sdp_node in sdp_nodes:
-            prefix = sdp_node.name + "_"
-            sdp_node = getCustomOp(sdp_node)
-            dataflow_model_filename = sdp_node.get_nodeattr("model")
-            kernel_model = ModelWrapper(dataflow_model_filename)
-            # InsertFIFO at this stage interferes with tLastMarker
-            # TODO: is this really needed here at all?
-            if not self.enable_instrumentation:
-                kernel_model = kernel_model.transform(InsertFIFO())
-            kernel_model = kernel_model.transform(SpecializeLayers(self.fpga_part))
-            kernel_model = kernel_model.transform(GiveUniqueNodeNames(prefix))
-            kernel_model.save(dataflow_model_filename)
-            kernel_model = kernel_model.transform(PrepareIP(self.fpga_part, self.period_ns))
-            kernel_model = kernel_model.transform(HLSSynthIP())
-            kernel_model = kernel_model.transform(
-                CreateStitchedIP(self.fpga_part, self.period_ns, sdp_node.onnx_node.name, False)
+        worker_args = [
+            (
+                sdp_node.name,
+                getCustomOp(sdp_node).get_nodeattr("model"),
+                self.fpga_part,
+                self.period_ns,
+                self.enable_instrumentation,
             )
-            kernel_model.set_metadata_prop("platform", "zynq-iodma")
-            kernel_model.save(dataflow_model_filename)
+            for sdp_node in sdp_nodes
+        ]
+        num_workers = get_num_default_workers()
+        if num_workers == 0:
+            num_workers = mp.cpu_count()
+        num_workers = min(num_workers, len(worker_args))
+        log.info(f"Building {len(worker_args)} SDP kernels with {num_workers} workers...")
+        if num_workers > 1:
+            with mp.Pool(num_workers) as pool:
+                pool.map(_build_sdp_kernel, worker_args, chunksize=1)
+        else:
+            for args in worker_args:
+                _build_sdp_kernel(args)
         # Assemble design from IPs
         model = model.transform(
             MakeZYNQProject(


### PR DESCRIPTION
## Summary

`merge/fifo_heuristic` mixed three unrelated efforts: (1) an upstream analytical/heuristic FIFO-sizing feature from Lukas Stasytis, (2) fixes on top of that feature, and (3) improvements to **Live FIFO sizing** plus some general build/tooling fixes. Since the analytical FIFO-sizing feature has since been fully removed from `dev`, this PR extracts only the parts of `merge/fifo_heuristic` that are still relevant: Live-FIFO-sizing-specific improvements and general-purpose fixes unrelated to the removed feature.

All commits from Lukas Stasytis / auphelia and every Felix Jentzsch commit that only touched analytical-FIFO-specific code (now removed from `dev`, e.g. `derive_characteristic.py`'s `JustInTimeSynthesize`, TAV/tree-model machinery in `hwcustomop.py`, the `skip_resynth_during_fifo_sizing` flag, `ci/cfg/baseline_fifosizing.yml`, `ci/cfg/default_fifosizing_sweep.yml`) were intentionally **not** ported.

## Changes

- **`[LiveFIFO] Adjust latency relaxation and iteration runtime heuristic`** — allow a small (0.05%) latency degradation on top of configured relaxation to account for observed jitter, and reduce the per-iteration rtlsim runtime heuristic multiplier from 10x to 4x free-running latency (squashed from 3 original commits, including a revert, into their net final state).
- **`Fix FIFO maxcount width`** — force a fixed 32-bit width for the simulation-only `count`/`maxcount` FIFO ports, since Live FIFO sizing dynamically probes depths larger than the node's declared depth during rtlsim.
- **`Parallelize stitched-IP creation of SDPs in ZynqBuild`** — build `StreamingDataflowPartition` kernels concurrently via a multiprocessing pool instead of sequentially. General build-speed improvement, unrelated to FIFO sizing.
- **`[CI] Choose best available live FIFO-sizing for follow-up run`** — `ci/collect/collect.py` now scans all available FIFO search-order results and picks the one with the lowest total FIFO size for follow-up benchmarking runs, instead of always hard-coding `largest_first`.
- **`[CI] Adjust live FIFO-sizing experiment config`** — disable verification for the transformer models in `ci/cfg/live_fifosizing.yml` to avoid skewing build-time measurements, and comment out a disabled ResNet-18 (CIFAR100) entry.

## Not ported (dropped)

- All analytical/heuristic FIFO-sizing feature code and CI experiment configs (feature fully removed from `dev`).
- A previously-needed SSL library CI workaround — confirmed no longer relevant on our current CI system.
- A `testing_util` import-path fix that only corrected breakage introduced while merging the analytical FIFO-sizing branch; `dev` already uses the correct import path everywhere.
- A `depth`/`tensor_size` rename in the removed `InsertAndSetFIFODepths` transformation class — the class no longer exists on `dev` and no equivalent bug pattern was found in its replacements.

## Validation

No local Poetry-managed FINN+ venv/finn CLI was available in this environment (per repo conventions, the pytest suite and hardware/Vivado-dependent builds only run via GitLab CI on the PC2 cluster). Validated via `py_compile`/`pyflakes` on all changed Python files and the repository's pre-commit hooks (isort/black/flake8), which passed on every commit.
