### PR TITLE
Validate that correct steps and outputs are in config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Please follow the steps below and be sure that your contribution complies with o
     We welcome submissions to:
 
     1. The FINN+ flow like additional custom ONNX nodes, transformation and analysis passes.
-    2. Contributions to the documentation and Jupyter notebooks
+    2. Contributions to the documentation
 
     To ensure clean separation of toolflow and examples. If you want to add example networks, please add them to the models folder -- Please also add a short description/instruction that we can put in our [Wiki](https://github.com/eki-project/finn-plus/wiki).
 
@@ -21,7 +21,7 @@ Please follow the steps below and be sure that your contribution complies with o
 
     3. Please install [pre-commit](https://pre-commit.com/) to ensure your code is formatted to our style guidelines. The hooks we use for pre-commit can be found in [this file](https://github.com/eki-project/finn-plus/blob/main/.pre-commit-config.yaml).
 
-    4. Modify the Python source code, Jupyter notebooks and Sphinx documentation etc. as needed.
+    4. Modify the Python source code and documentation etc. as needed.
 
     5. Use *git add*, *git commit*, *git push* to add changes to your fork.
 

--- a/src/finn/builder/build_dataflow.py
+++ b/src/finn/builder/build_dataflow.py
@@ -54,6 +54,7 @@ from typing import Any, TextIO
 import finn.util.logging
 from finn.builder.build_dataflow_config import (
     DataflowBuildConfig,
+    DataflowOutputType,
     LogLevel,
     default_build_dataflow_steps,
     to_logging_level,
@@ -191,6 +192,64 @@ def resolve_build_steps(cfg: DataflowBuildConfig, partial: bool = True) -> list[
         else transform_step
         for transform_step in steps_as_fxns
     ]
+
+
+def validate_steps(cfg: DataflowBuildConfig) -> None:
+    """Check that `steps` is internally well-ordered and covers `generate_outputs`.
+
+    Each output-producing step decides whether to do its work by checking
+    `generate_outputs` itself, so a custom `steps` list that drops one of them silently
+    produces no output and no error - or, worse, a downstream step still runs and fails
+    with a confusing low-level error because the artifact it depends on was never
+    created, or was never created *yet*. This resolves `steps` to callables (the full,
+    unfiltered list - `start_step`/`stop_step` only skip *running* steps that already
+    ran in a previous invocation, they don't mean the output was never produced) and
+    walks it in order, tracking outputs produced so far via each step's
+    `produces_outputs` attribute:
+
+    - a step's `consumes_outputs` (both attributes stamped on by
+      `register_build_dataflow_step` for steps that declare them, or set directly on a
+      custom step's function) must already be in that running set - otherwise the step
+      list is misordered, regardless of `generate_outputs`;
+    - once the full list has run, every requested `generate_outputs` entry must be in
+      the accumulated set - otherwise no step in `steps` produces it at all. Skipped for
+      the default step list, since it contains every producer step by construction.
+
+    Args:
+        cfg: Build configuration to check.
+
+    Raises:
+        FINNConfigurationError: If a step's `consumes_outputs` is not satisfied by an
+            earlier step in `steps`, or if `generate_outputs` requests an output that no
+            step in `steps` produces at all.
+    """
+    resolved_steps = resolve_build_steps(cfg, partial=False)
+    produced: set[DataflowOutputType] = set()
+    for step in resolved_steps:
+        consumed = getattr(step, "consumes_outputs", ())
+        missing = [output_type for output_type in consumed if output_type not in produced]
+        if missing:
+            missing_names = ", ".join(output_type.value for output_type in missing)
+            raise FINNConfigurationError(
+                f"Step '{step.__name__}' requires {missing_names} to already be produced "
+                "by an earlier step in `steps`, but no earlier step produces "
+                f"{'it' if len(missing) == 1 else 'them'}. Check the order of `steps`."
+            )
+        produced.update(getattr(step, "produces_outputs", ()))
+
+    if cfg.steps is None:
+        # The default step list contains every producer step - nothing left to check.
+        return
+
+    missing_outputs = set(cfg.generate_outputs) - produced
+    if missing_outputs:
+        missing_names = ", ".join(sorted(output_type.value for output_type in missing_outputs))
+        raise FINNConfigurationError(
+            f"generate_outputs requests {missing_names}, but no step in `steps` produces "
+            f"{'it' if len(missing_outputs) == 1 else 'them'}. Add the step that produces "
+            f"{'it' if len(missing_outputs) == 1 else 'them'}, or leave `steps` unset to "
+            "use the default step list."
+        )
 
 
 def resolve_step_filename(step_name: str, cfg: DataflowBuildConfig, step_delta: int = 0) -> Path:
@@ -388,6 +447,9 @@ def build_dataflow_cfg(model_filename: str | Path, cfg: DataflowBuildConfig) -> 
         # directly in Python rather than via DataflowBuildConfig.construct_from, which
         # skips that validation) before spending any time on the build itself.
         cfg.validate_generate_outputs()
+        # Needs resolved step callables, so it can only run here, not in
+        # DataflowBuildConfig.validate_generate_outputs (see that method's docstring).
+        validate_steps(cfg)
 
         model = create_model_wrapper(model_filename, cfg)
         build_dataflow_steps: list[BuildStep] = resolve_build_steps(cfg)

--- a/src/finn/builder/build_dataflow.py
+++ b/src/finn/builder/build_dataflow.py
@@ -384,6 +384,11 @@ def build_dataflow_cfg(model_filename: str | Path, cfg: DataflowBuildConfig) -> 
     # Setup done, start build flow
     time_per_step: dict[str, float] = {}
     try:
+        # Catch unsupported generate_outputs combinations here (e.g. a config built
+        # directly in Python rather than via DataflowBuildConfig.construct_from, which
+        # skips that validation) before spending any time on the build itself.
+        cfg.validate_generate_outputs()
+
         model = create_model_wrapper(model_filename, cfg)
         build_dataflow_steps: list[BuildStep] = resolve_build_steps(cfg)
 

--- a/src/finn/builder/build_dataflow_config.py
+++ b/src/finn/builder/build_dataflow_config.py
@@ -224,20 +224,6 @@ estimate_only_dataflow_steps = [
 #: without any synthesis.
 hw_codegen_dataflow_steps = [*estimate_only_dataflow_steps, "step_hw_codegen"]
 
-#: Maps each output product to the name of the step that produces it, so that a
-#: custom `steps` list can be checked for completeness against `generate_outputs`.
-#: `RTLSIM_PERFORMANCE` is deliberately absent: `step_measure_rtlsim_performance` does
-#: not gate its work on `generate_outputs`, so there is nothing to check for it.
-_OUTPUT_TYPE_TO_STEP: dict[DataflowOutputType, str] = {
-    DataflowOutputType.ESTIMATE_REPORTS: "step_generate_estimate_reports",
-    DataflowOutputType.STITCHED_IP: "step_create_stitched_ip",
-    DataflowOutputType.OOC_SYNTH: "step_out_of_context_synthesis",
-    DataflowOutputType.BITFILE: "step_synthesize_bitfile",
-    DataflowOutputType.PYNQ_DRIVER: "step_make_driver",
-    DataflowOutputType.CPP_DRIVER: "step_make_driver",
-    DataflowOutputType.DEPLOYMENT_PACKAGE: "step_deployment_package",
-}
-
 
 @dataclass
 class DataflowBuildConfig(DataClassJSONMixin, DataClassYAMLMixin):
@@ -311,24 +297,23 @@ class DataflowBuildConfig(DataClassJSONMixin, DataClassYAMLMixin):
 
     def validate_generate_outputs(self) -> None:
         """Check that `generate_outputs` does not request an output product whose
-        prerequisite output product is missing, and that `steps` (if customized)
-        still contains the step that produces each requested output.
+        prerequisite output product is missing.
 
         Some output products are built on top of others (e.g. out-of-context synthesis
         needs the stitched IP), but the steps that produce them only discover a missing
         prerequisite once they run - potentially after other steps have already spent
-        hours on synthesis. Likewise, each output-producing step decides whether to do
-        its work by checking `generate_outputs` itself, so a custom `steps` list that
-        drops one of them silently produces no output and no error - or, worse, a
-        downstream step still runs and fails with a confusing low-level error because
-        the artifact it depends on was never created. Catching both cases at
-        config-validation time instead avoids wasting time on a build that was always
-        going to fail.
+        hours on synthesis. Catching this at config-validation time instead avoids
+        wasting that time on a build that was always going to fail.
+
+        This only checks `generate_outputs` itself. Whether `steps` actually contains a
+        step that produces each requested output is checked separately, in
+        `build_dataflow.validate_steps_produce_outputs`, once `steps` has been resolved
+        to callables - that cannot happen here without a circular import on
+        `build_dataflow_steps`.
 
         Raises:
             FINNConfigurationError: If `generate_outputs` contains an output product
-                without a prerequisite it depends on, or without its producing step
-                present in `steps`.
+                without a prerequisite it depends on.
         """
         requested = set(self.generate_outputs)
 
@@ -355,26 +340,6 @@ class DataflowBuildConfig(DataClassJSONMixin, DataClassYAMLMixin):
                     "generate_outputs requests deployment_package, which requires "
                     "either pynq_driver or cpp_driver to also be requested. Add one "
                     "of them to generate_outputs."
-                )
-
-        # `steps` defaulting to None means the default step list is used, which
-        # contains every producer step - nothing to check in that case.
-        if self.steps is None:
-            return
-
-        step_names: set[str] = set()
-        for step in self.steps:
-            if isinstance(step, str):
-                step_names.add(step)
-            elif callable(step):
-                step_names.add(getattr(step, "__name__", ""))
-
-        for output_type, required_step in _OUTPUT_TYPE_TO_STEP.items():
-            if output_type in requested and required_step not in step_names:
-                raise FINNConfigurationError(
-                    f"generate_outputs requests {output_type.value}, which requires "
-                    f"the step '{required_step}' to be present in `steps`. Add it, or "
-                    "leave `steps` unset to use the default step list."
                 )
 
     def correct_paths(self) -> None:

--- a/src/finn/builder/build_dataflow_config.py
+++ b/src/finn/builder/build_dataflow_config.py
@@ -224,6 +224,20 @@ estimate_only_dataflow_steps = [
 #: without any synthesis.
 hw_codegen_dataflow_steps = [*estimate_only_dataflow_steps, "step_hw_codegen"]
 
+#: Maps each output product to the name of the step that produces it, so that a
+#: custom `steps` list can be checked for completeness against `generate_outputs`.
+#: `RTLSIM_PERFORMANCE` is deliberately absent: `step_measure_rtlsim_performance` does
+#: not gate its work on `generate_outputs`, so there is nothing to check for it.
+_OUTPUT_TYPE_TO_STEP: dict[DataflowOutputType, str] = {
+    DataflowOutputType.ESTIMATE_REPORTS: "step_generate_estimate_reports",
+    DataflowOutputType.STITCHED_IP: "step_create_stitched_ip",
+    DataflowOutputType.OOC_SYNTH: "step_out_of_context_synthesis",
+    DataflowOutputType.BITFILE: "step_synthesize_bitfile",
+    DataflowOutputType.PYNQ_DRIVER: "step_make_driver",
+    DataflowOutputType.CPP_DRIVER: "step_make_driver",
+    DataflowOutputType.DEPLOYMENT_PACKAGE: "step_deployment_package",
+}
+
 
 @dataclass
 class DataflowBuildConfig(DataClassJSONMixin, DataClassYAMLMixin):
@@ -291,7 +305,77 @@ class DataflowBuildConfig(DataClassJSONMixin, DataClassYAMLMixin):
                 f"No folding config file could be found at {dfbc.folding_config_file}."
             )
 
+        dfbc.validate_generate_outputs()
+
         return dfbc
+
+    def validate_generate_outputs(self) -> None:
+        """Check that `generate_outputs` does not request an output product whose
+        prerequisite output product is missing, and that `steps` (if customized)
+        still contains the step that produces each requested output.
+
+        Some output products are built on top of others (e.g. out-of-context synthesis
+        needs the stitched IP), but the steps that produce them only discover a missing
+        prerequisite once they run - potentially after other steps have already spent
+        hours on synthesis. Likewise, each output-producing step decides whether to do
+        its work by checking `generate_outputs` itself, so a custom `steps` list that
+        drops one of them silently produces no output and no error - or, worse, a
+        downstream step still runs and fails with a confusing low-level error because
+        the artifact it depends on was never created. Catching both cases at
+        config-validation time instead avoids wasting time on a build that was always
+        going to fail.
+
+        Raises:
+            FINNConfigurationError: If `generate_outputs` contains an output product
+                without a prerequisite it depends on, or without its producing step
+                present in `steps`.
+        """
+        requested = set(self.generate_outputs)
+
+        if (
+            DataflowOutputType.OOC_SYNTH in requested
+            and DataflowOutputType.STITCHED_IP not in requested
+        ):
+            raise FINNConfigurationError(
+                "generate_outputs requests out_of_context_synth, which requires "
+                "stitched_ip to also be requested. Add stitched_ip to generate_outputs."
+            )
+
+        if DataflowOutputType.DEPLOYMENT_PACKAGE in requested:
+            if DataflowOutputType.BITFILE not in requested:
+                raise FINNConfigurationError(
+                    "generate_outputs requests deployment_package, which requires "
+                    "bitfile to also be requested. Add bitfile to generate_outputs."
+                )
+            if (
+                DataflowOutputType.PYNQ_DRIVER not in requested
+                and DataflowOutputType.CPP_DRIVER not in requested
+            ):
+                raise FINNConfigurationError(
+                    "generate_outputs requests deployment_package, which requires "
+                    "either pynq_driver or cpp_driver to also be requested. Add one "
+                    "of them to generate_outputs."
+                )
+
+        # `steps` defaulting to None means the default step list is used, which
+        # contains every producer step - nothing to check in that case.
+        if self.steps is None:
+            return
+
+        step_names: set[str] = set()
+        for step in self.steps:
+            if isinstance(step, str):
+                step_names.add(step)
+            elif callable(step):
+                step_names.add(getattr(step, "__name__", ""))
+
+        for output_type, required_step in _OUTPUT_TYPE_TO_STEP.items():
+            if output_type in requested and required_step not in step_names:
+                raise FINNConfigurationError(
+                    f"generate_outputs requests {output_type.value}, which requires "
+                    f"the step '{required_step}' to be present in `steps`. Add it, or "
+                    "leave `steps` unset to use the default step list."
+                )
 
     def correct_paths(self) -> None:
         """Fix paths by (if needed) joining them with the config path, so that

--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -171,7 +171,7 @@ from finn.transformation.streamline.reorder import MakeMaxPoolNHWC
 from finn.transformation.streamline.round_thresholds import RoundAndClipThresholds
 from finn.util.basic import get_liveness_threshold_cycles, get_rtlsim_trace_depth, getHWCustomOp
 from finn.util.config import extract_model_config_to_json
-from finn.util.exception import FINNUserError
+from finn.util.exception import FINNConfigurationError, FINNUserError
 from finn.util.execution import execute_parent
 from finn.util.logging import log
 from finn.util.mlo_sim import is_mlo, mlo_prehook_func_factory
@@ -1546,7 +1546,11 @@ def step_out_of_context_synthesis(model: ModelWrapper, cfg: DataflowBuildConfig)
     """Run out-of-context synthesis and generate reports.
     Depends on the DataflowOutputType.STITCHED_IP output product."""
     if DataflowOutputType.OOC_SYNTH in cfg.generate_outputs:
-        assert DataflowOutputType.STITCHED_IP in cfg.generate_outputs, "OOC needs stitched IP"
+        if DataflowOutputType.STITCHED_IP not in cfg.generate_outputs:
+            raise FINNConfigurationError(
+                "generate_outputs requests out_of_context_synth, which requires "
+                "stitched_ip to also be requested. Add stitched_ip to generate_outputs."
+            )
         model = model.transform(
             SynthOutOfContext(part=cfg._resolve_fpga_part(), clk_period_ns=cfg.synth_clk_period_ns)
         )

--- a/src/finn/builder/build_dataflow_steps.py
+++ b/src/finn/builder/build_dataflow_steps.py
@@ -188,10 +188,30 @@ build_dataflow_step_lookup: dict[str, BuildDataflowStep] = {}
 
 def register_build_dataflow_step(
     step_name: str | None = None,
+    produces_outputs: list[DataflowOutputType] | None = None,
+    consumes_outputs: list[DataflowOutputType] | None = None,
 ) -> Callable[[BuildDataflowStep], BuildDataflowStep]:
     """Register a dataflow build step.
 
     Uses the function name by default, unless step_name is explicitly provided.
+
+    Args:
+        step_name: Name to register the step under. Defaults to the function name.
+        produces_outputs: Output product(s) this step is responsible for, if any. Stamped
+            onto the function as a `produces_outputs` attribute, which
+            `build_dataflow.validate_steps` reads to check that a custom `steps` list still
+            covers every requested `generate_outputs` entry, and to know what is available
+            to later steps' `consumes_outputs`. A step that does not produce a tracked
+            output (most steps) should leave this unset.
+        consumes_outputs: Output product(s) this step requires to already have been
+            produced by an earlier step, if any. Stamped onto the function as a
+            `consumes_outputs` attribute, which `build_dataflow.validate_steps` reads to
+            enforce step ordering: it is a `FINNConfigurationError` for a step to run
+            before whatever produces something it consumes.
+
+    Custom steps that are not registered via this decorator (dotted import path, raw
+    callable) can opt into both checks the same way, by setting the attributes directly,
+    e.g. `my_step.produces_outputs = [DataflowOutputType.STITCHED_IP]`.
     """
 
     def _decorator(step_fn: BuildDataflowStep) -> BuildDataflowStep:
@@ -200,6 +220,10 @@ def register_build_dataflow_step(
         if key in build_dataflow_step_lookup:
             raise ValueError(f"Duplicate build step registration: {key}")
         build_dataflow_step_lookup[key] = step_fn
+        if produces_outputs is not None:
+            step_fn.produces_outputs = produces_outputs  # type: ignore[attr-defined]
+        if consumes_outputs is not None:
+            step_fn.consumes_outputs = consumes_outputs  # type: ignore[attr-defined]
         return step_fn
 
     return _decorator
@@ -1172,7 +1196,7 @@ def step_apply_folding_config(model: ModelWrapper, cfg: DataflowBuildConfig) -> 
     return model
 
 
-@register_build_dataflow_step()
+@register_build_dataflow_step(produces_outputs=[DataflowOutputType.ESTIMATE_REPORTS])
 def step_generate_estimate_reports(model: ModelWrapper, cfg: DataflowBuildConfig) -> ModelWrapper:
     """Generate per-layer resource and cycle estimates using analytical models."""
     if DataflowOutputType.ESTIMATE_REPORTS in cfg.generate_outputs:
@@ -1309,7 +1333,7 @@ def verify_mlo(model: ModelWrapper, cfg: DataflowBuildConfig, step: str) -> None
     verify_step(model, cfg, "stitched_ip_rtlsim", need_parent=False, rtlsim_pre_hook=mlo_prehook)
 
 
-@register_build_dataflow_step()
+@register_build_dataflow_step(produces_outputs=[DataflowOutputType.STITCHED_IP])
 def step_create_stitched_ip(model: ModelWrapper, cfg: DataflowBuildConfig) -> ModelWrapper:
     """Create stitched IP for a graph after all HLS IP blocks have been generated.
     Depends on the DataflowOutputType.STITCHED_IP output product."""
@@ -1400,7 +1424,7 @@ def step_create_stitched_ip(model: ModelWrapper, cfg: DataflowBuildConfig) -> Mo
     return model
 
 
-@register_build_dataflow_step()
+@register_build_dataflow_step(produces_outputs=[DataflowOutputType.RTLSIM_PERFORMANCE])
 def step_measure_rtlsim_performance(model: ModelWrapper, cfg: DataflowBuildConfig) -> ModelWrapper:
     """Measure performance + latency of stitched-IP model in rtlsim (xsi)."""
     report_dir = Path(cfg.output_dir) / "report"
@@ -1483,7 +1507,9 @@ def step_measure_rtlsim_performance(model: ModelWrapper, cfg: DataflowBuildConfi
     return model
 
 
-@register_build_dataflow_step()
+@register_build_dataflow_step(
+    produces_outputs=[DataflowOutputType.PYNQ_DRIVER, DataflowOutputType.CPP_DRIVER]
+)
 def step_make_driver(model: ModelWrapper, cfg: DataflowBuildConfig) -> ModelWrapper:
     """Create a driver that can be used to interface the generated accelerator.
     Use DataflowBuildConfig to select PYNQ Python or C++ driver."""
@@ -1541,7 +1567,10 @@ def step_make_driver(model: ModelWrapper, cfg: DataflowBuildConfig) -> ModelWrap
     return model
 
 
-@register_build_dataflow_step()
+@register_build_dataflow_step(
+    produces_outputs=[DataflowOutputType.OOC_SYNTH],
+    consumes_outputs=[DataflowOutputType.STITCHED_IP],
+)
 def step_out_of_context_synthesis(model: ModelWrapper, cfg: DataflowBuildConfig) -> ModelWrapper:
     """Run out-of-context synthesis and generate reports.
     Depends on the DataflowOutputType.STITCHED_IP output product."""
@@ -1598,7 +1627,7 @@ def step_vivado_power_estimation(model: ModelWrapper, cfg: DataflowBuildConfig) 
     return model
 
 
-@register_build_dataflow_step()
+@register_build_dataflow_step(produces_outputs=[DataflowOutputType.BITFILE])
 def step_synthesize_bitfile(model: ModelWrapper, cfg: DataflowBuildConfig) -> ModelWrapper:
     """Synthesize a bitfile for the using the specified shell flow, using either
     Vivado or Vitis, to target the specified board."""
@@ -1720,7 +1749,14 @@ def step_synthesize_bitfile(model: ModelWrapper, cfg: DataflowBuildConfig) -> Mo
     return model
 
 
-@register_build_dataflow_step()
+@register_build_dataflow_step(
+    produces_outputs=[DataflowOutputType.DEPLOYMENT_PACKAGE],
+    consumes_outputs=[
+        DataflowOutputType.BITFILE,
+        DataflowOutputType.PYNQ_DRIVER,
+        DataflowOutputType.CPP_DRIVER,
+    ],
+)
 def step_deployment_package(model: ModelWrapper, cfg: DataflowBuildConfig) -> ModelWrapper:
     """Create a deployment package including the driver and bitfile."""
     if DataflowOutputType.DEPLOYMENT_PACKAGE in cfg.generate_outputs:


### PR DESCRIPTION
This PR adds validation on the build config, that if a output in the generate_outputs list is set, then also the corresponding step should be in the step list. Additionally, it checks, that if a step depends on the output of a previous step, then the output of the previous step needs to be in the generate_outputs list.