### PR TITLE
Make dependency checks more robust and relax caching in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -136,7 +136,9 @@ Build:
       - tests/dist/*.whl
     expire_in: 1 week
   cache:
-    key: $CI_COMMIT_SHA #TODO: cache based on relevant files
+    key:
+      files:
+        - external_dependencies.yaml
     paths:
       - deps
 
@@ -157,7 +159,9 @@ FINN Test Suite 2024.2:
     # Always run, as long as there was no prior failure
     - when: on_success
   cache:
-    key: $CI_COMMIT_SHA
+    key:
+      files:
+        - external_dependencies.yaml
     policy: pull
     paths:
       - deps

--- a/ci/.gitlab-bench.yml
+++ b/ci/.gitlab-bench.yml
@@ -41,7 +41,9 @@ FINN Build:
       dvc pull
       finn bench --dependency-path ./deps --build-path $FINN_BUILD_DIR --num-default-workers $BENCH_FINN_WORKERS --bench_config $BENCH_CFG
   cache:
-    key: $CI_COMMIT_SHA
+    key:
+      files:
+        - external_dependencies.yaml
     policy: pull
     paths:
       - deps
@@ -149,7 +151,9 @@ FINN Build (Follow-up):
       dvc pull
       finn bench --dependency-path ./deps --build-path $FINN_BUILD_DIR --num-default-workers $BENCH_FINN_WORKERS --bench_config followup
   cache:
-    key: $CI_COMMIT_SHA
+    key:
+      files:
+        - external_dependencies.yaml
     policy: pull
     paths:
       - deps

--- a/src/finn/interface/manage_deps.py
+++ b/src/finn/interface/manage_deps.py
@@ -33,6 +33,12 @@ from finn.util.exception import (
 
 from pydantic.networks import HttpUrl  # noqa
 
+# Timeout for the header-only request used to check whether a download is outdated
+HTTP_HEADER_TIMEOUT_S = 10.0
+
+# Headers used to identify the remote file version, in order of preference
+VERSION_HEADERS = ("etag", "last-modified", "content-length")
+
 
 class Dependency:
     """Baseclass for all dependencies."""
@@ -411,6 +417,45 @@ class DependencyUpdater:
             shutil.copytree(source, target)
         return not self.is_outdated(package_name)
 
+    def _version_file(self, url: str, target_directory: Path) -> Path:
+        """Return the path of the sidecar file caching the version token of a download."""
+        return target_directory / f".{Path(url).name}.version"
+
+    def _get_remote_version_token(self, url: str) -> str | None:
+        """Return an opaque token identifying the current remote version of the file.
+
+        Uses the ETag header if available, otherwise Last-Modified, otherwise Content-Length.
+        Returns None if the server is unreachable or provides none of these headers.
+        """
+        try:
+            result = sp.run(
+                shlex.split(
+                    f"wget --spider --server-response --tries=1 "
+                    f"--timeout={HTTP_HEADER_TIMEOUT_S} {url}"
+                ),
+                capture_output=True,
+                text=True,
+                timeout=HTTP_HEADER_TIMEOUT_S,
+            )
+        except sp.TimeoutExpired:
+            debug(f"[{url}] Timed out while requesting headers.", False)
+            return None
+        if result.returncode != 0:
+            debug(f"[{url}] Header request failed:\n{result.stderr.strip()}", False)
+            return None
+
+        # Headers of every redirect hop are printed, so later hops overwrite earlier ones
+        headers: dict[str, str] = {}
+        for line in result.stderr.splitlines():
+            name, separator, value = line.strip().partition(":")
+            if separator and name.lower() in VERSION_HEADERS:
+                headers[name.lower()] = value.strip()
+        for header in VERSION_HEADERS:
+            if headers.get(header):
+                return f"{header}={headers[header]}"
+        debug(f"[{url}] Server provided no version headers.", False)
+        return None
+
     def _install_direct_download_dependency(self, package_name: str) -> bool:
         """Install a direct download dependency. Return success."""
         debug(f"Trying to install DIRECT DOWNLOAD dependency: {package_name}", False)
@@ -424,6 +469,12 @@ class DependencyUpdater:
         )
         url = str(url)
         target: Path = self.dep_location / target_directory
+        if not target.exists():
+            target.mkdir(parents=True)
+
+        # Query the version token before downloading so it matches the fetched content
+        remote_token = self._get_remote_version_token(url)
+        version_file = self._version_file(url, target)
 
         # Return if the download fails
         # Automatically skips if not modified
@@ -436,6 +487,8 @@ class DependencyUpdater:
             debug(f"[{package_name}] wget failed!", False)
             return False
         if "304 Not Modified" in wget_download.stderr.strip() and unzipped.exists():
+            if remote_token is not None:
+                version_file.write_text(remote_token)
             return True
 
         debug(f"[{package_name}] Removing previous install if necessary.", False)
@@ -447,7 +500,11 @@ class DependencyUpdater:
         if do_unzip:  # noqa
             if self._run_silent(f"unzip -o {Path(url).name}", cwd=target) != 0:
                 return False
-        return unzipped.exists()
+        if not unzipped.exists():
+            return False
+        if remote_token is not None:
+            version_file.write_text(remote_token)
+        return True
 
     def install_dependency(self, package_name: str) -> bool:
         """Install the dependency in the dependency location. If no definition for this dependency
@@ -473,26 +530,42 @@ class DependencyUpdater:
                 f"Cannot check if non-existing dependency {package_name} is outdated."
             )
         if package_name in self.deps.direct_download_deps:
-            # TODO: Improve (e.g. by checking directly instead of by using wget).
-            # Check by letting wget compare timestamps. To avoid large wait times
-            # immediately delete the file again after a short timeout.
+            # Not all servers send Last-Modified (which "wget -N" relies on), so compare an
+            # ETag/Last-Modified/Content-Length token against the one cached at install time.
             data = cast("DirectDownloadDependency", data)
-            target = self.dep_location / data.target_directory / Path(str(data.url)).name
-            if not target.parent.exists():
-                target.parent.mkdir(parents=True)
-            wget_result = sp.run(
-                shlex.split(f"wget -N {data.url}"),
-                cwd=target.parent,
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-            if "304 Not Modified" in wget_result.stderr.strip():
-                return False
-            debug(wget_result.stderr.strip(), False)
-            if target.exists():
-                target.unlink()
-            return True
+            url = str(data.url)
+            target_directory = self.dep_location / data.target_directory
+            if not target_directory.exists():
+                target_directory.mkdir(parents=True)
+            installed_artifact = (target_directory / Path(url).name).with_suffix("")
+            version_file = self._version_file(url, target_directory)
+
+            remote_token = self._get_remote_version_token(url)
+            if remote_token is None:
+                # Without a reachable server we cannot tell, so keep a working installation
+                if installed_artifact.exists():
+                    debug(
+                        f"[{package_name}] Cannot determine remote version, "
+                        f"keeping the existing installation.",
+                        False,
+                    )
+                    return False
+                return True
+            if not installed_artifact.exists():
+                debug(f"[{package_name}] Not installed yet - outdated.", False)
+                return True
+            if not version_file.exists():
+                debug(f"[{package_name}] No cached version token - outdated.", False)
+                return True
+            local_token = version_file.read_text().strip()
+            if local_token != remote_token:
+                debug(
+                    f"[{package_name}] Version mismatch: expected {remote_token}, "
+                    f"got {local_token}",
+                    False,
+                )
+                return True
+            return False
 
         # Compare hashes for git dependencies and boardfiles
         # Try to fetch the current hash


### PR DESCRIPTION
## Make direct-download dependency checks robust &amp; cache deps by definition file

### Problem

Two independent issues caused dependencies to be re-fetched on nearly every run:

**1. `pynq-z1` was re-downloaded every single time.** The outdated-check for `direct_download_deps` used `wget -N`, which is purely timestamp-based and needs a `Last-Modified` header. `raw.githubusercontent.com` (where the GitHub `/raw/` URL redirects) sends only an `ETag`:

| URL | `Last-Modified` | `ETag` |
|---|---|---|
| `dpoauwgwqsy2x.cloudfront.net/.../pynq-z2.zip` | yes | yes |
| `github.com/.../raw/master/pynq-z1.zip` | **no** | yes |

Without `Last-Modified`, wget never receives a `304 Not Modified`, so the check always reported &quot;outdated&quot; and triggered a full re-download plus re-unzip. The check also downloaded the file just to probe it and then `unlink()`ed it, under a hard `timeout=5` that could raise `TimeoutExpired` on a slow link.

**2. The CI `deps` cache was keyed on `$CI_COMMIT_SHA`,** so every commit produced a fresh cache key and every pipeline re-fetched all dependencies from scratch — even when the dependency set was unchanged. (There was already a `#TODO: cache based on relevant files` noting this.)

### Changes

**`manage_deps.py`**

- New `_get_remote_version_token(url)`: performs a header-only request (`wget --spider --server-response --tries=1 --timeout=10`) and derives an opaque version token from the first available of `ETag`, `Last-Modified`, `Content-Length`. Headers from every redirect hop are parsed with later hops overwriting earlier ones, so the final `200` response wins.
- New `_version_file(url, dir)`: sidecar cache at `&lt;target_dir&gt;/.&lt;filename&gt;.version`.
- `is_outdated()` now compares the remote token against the one cached at install time instead of abusing `wget -N`. The download-then-`unlink` hack and the 5 s hard timeout are gone.
- `_install_direct_download_dependency()` queries the token *before* downloading and writes the sidecar after a successful install, including on the `304` fast path.
- **Offline tolerance:** if the server is unreachable or exposes none of the version headers, an existing local artifact is kept (`not outdated`) rather than being deleted and re-fetched. If no local artifact exists, it still reports outdated so the install runs and fails visibly.

**`.gitlab-ci.yml` / `.gitlab-bench.yml`**

All four `deps` cache blocks (`Build`, `FINN Test Suite 2024.2`, `FINN Build`, `FINN Build (Follow-up)`) now use:

```yaml
cache:
  key:
    files:
      - external_dependencies.yaml
  paths:
    - deps
```

GitLab hashes the file contents, so the cache is reused across all commits that don't change the dependency set and invalidated automatically when they do.

### Testing

Verified locally against a scratch dependency directory:

| Case | Result |
|---|---|
| `pynq-z1` (GitHub raw, ETag only) — install, then re-check | up to date (previously: always re-downloaded) |
| `pynq-z2` (CloudFront) — install, then re-check | up to date |
| Tampered sidecar token | outdated |
| Unreachable host, artifact present | not outdated (kept) |
| Unreachable host, artifact missing | outdated |

Both YAML files parse and the resulting cache blocks were confirmed.

### Notes / trade-offs

- The check costs one extra header-only request per direct-download dependency, replacing what was previously a full file download.
- Version tokens are server-specific: changing a dependency's URL to a different host causes one re-download even if the content is identical.
- The deps cache is per-runner, so the first pipeline after this change repopulates it on each runner.
- Since the cache no longer rotates per commit, a corrupted `deps` directory persists until `external_dependencies.yaml` changes or the cache is cleared manually. The new token check mitigates this for direct downloads by re-validating rather than trusting the cached copy blindly.