### PR TITLE
[Tests] Use TorchScript exporter for ResNet

### DIFF
--- a/tests/fpgadataflow/multifpga/utils.py
+++ b/tests/fpgadataflow/multifpga/utils.py
@@ -107,7 +107,9 @@ def _create_rn18_onnx(path: Path, w: int, a: int, classes: int = 100) -> None:
     model.eval()
     inp = torch.zeros((1, 3, 32, 32))
     _ = model(inp)
-    export_qonnx(model, (inp,), str(path.absolute()))
+    # The Dynamo exporter treats residual QuantTensor additions as unsupported.
+    # Use Brevitas' TorchScript exporter for this test model instead.
+    export_qonnx(model, (inp,), str(path.absolute()), dynamo=False)
 
 
 def generate_rn18(


### PR DESCRIPTION
## What changed

Force Brevitas' legacy TorchScript exporter for the generated ResNet used by the Multi-FPGA tests.

## Why

With newer PyTorch/Brevitas versions, the default Dynamo ONNX exporter fails in the ResNet residual block because traced branches no longer preserve `QuantTensor` wrappers, triggering `AssertionError: Perform add among QuantTensors`. The legacy exporter succeeds and preserves the existing test model and partitioning behavior.

## Upstream issue
-> https://github.com/Xilinx/brevitas/issues/1608