### PR TITLE
Fix MultiFPGA test markers

### DIFF
--- a/tests/fpgadataflow/multifpga/test_multifpga_aurora.py
+++ b/tests/fpgadataflow/multifpga/test_multifpga_aurora.py
@@ -73,6 +73,7 @@ class TestAuroraFlowPreparationAndMetadata:
     """Tests about the kernel preparation and metadata creation."""
 
     @pytest.mark.slow
+    @pytest.mark.vivado
     @pytest.mark.parametrize("device_node_combinations", [(1, 2), (1, 3), (2, 2), (5, 10), (5, 11)])
     @pytest.mark.parametrize("assignment_type", ["random", "equal"])
     @pytest.mark.parametrize("shuffle_devices", [True, False])
@@ -162,8 +163,8 @@ class TestAuroraFlowPreparationAndMetadata:
                 assert aurora.aurora_xo is not None
                 assert aurora.aurora_xo.exists()
 
-    @pytest.mark.multifpga
     @pytest.mark.slow
+    @pytest.mark.vivado
     def test_aurora_package_single(
         self, communication_kernel_args: dict[str, str], board: str, topology: MFTopology
     ) -> None:
@@ -204,6 +205,7 @@ class TestAuroraFlowPreparationAndMetadata:
 
 
 @pytest.mark.auroraflow
+@pytest.mark.multifpga
 @pytest.mark.parametrize("board", ["U55C", "Pynq-Z1"])
 @pytest.mark.parametrize("topology", [MFTopology.CHAIN])
 class TestAuroraFlowPartitioning:
@@ -249,6 +251,8 @@ class TestAuroraFlowPartitioning:
                 return True
         return False
 
+    @pytest.mark.vivado
+    @pytest.mark.slow
     @pytest.mark.parametrize(
         "model_type",
         [
@@ -449,6 +453,8 @@ class TestAuroraFlowPartitioning:
             for successor_node in suc:
                 assert abs(solution[successor_node.name] - solution[node.name]) <= 1
 
+    @pytest.mark.vivado
+    @pytest.mark.slow
     @pytest.mark.parametrize(
         "model_type",
         [

--- a/tests/fpgadataflow/multifpga/test_multifpga_end2end.py
+++ b/tests/fpgadataflow/multifpga/test_multifpga_end2end.py
@@ -24,6 +24,9 @@ execution environment with driver testing.
 # from finn.util.basic import make_build_dir
 #
 #
+# @pytest.mark.slow
+# @pytest.mark.vivado
+# @pytest.mark.multifpga
 # @pytest.mark.parametrize(
 #     "fpgas,synth_clk_period_ns,target_fps,mvau_wwidth_max,folding_two_pass,max_util,communication_kernel,topology,partition_strategy",
 #     [

--- a/tests/fpgadataflow/multifpga/test_multifpga_inseparable_nodes.py
+++ b/tests/fpgadataflow/multifpga/test_multifpga_inseparable_nodes.py
@@ -98,6 +98,7 @@ graphs = {
 }
 
 
+@pytest.mark.multifpga
 @pytest.mark.parametrize(
     "graph_data",
     [
@@ -147,6 +148,9 @@ def test_correct_output_count() -> None:
     assert len(_get_end_nodes_nx(graphs["two_output_graph"][0])) == 2
 
 
+@pytest.mark.vivado
+@pytest.mark.multifpga
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "model_type",
     [
@@ -206,6 +210,7 @@ def test_onnx_to_networkx(
         assert data["onnx_node"] in model.graph.node
 
 
+@pytest.mark.multifpga
 @pytest.mark.parametrize(
     "graph_data",
     [
@@ -250,6 +255,9 @@ def test_inseparable_nodes_qonnx(graph_data: tuple[DiGraph, list[list[str]]]) ->
         )
 
 
+@pytest.mark.multifpga
+@pytest.mark.vivado
+@pytest.mark.slow
 def test_resnet18_examples_inseparable_nodes(pytestconfig: pytest.Config) -> None:
     """Test that the expected number of inseparable-node groups and
     group-sizes are found for the Resnet18.

--- a/tests/fpgadataflow/multifpga/test_multifpga_metadata.py
+++ b/tests/fpgadataflow/multifpga/test_multifpga_metadata.py
@@ -64,6 +64,8 @@ def sdp_model(partition_topology: MFTopology) -> ModelWrapper:  # noqa
     return ModelWrapper(qonnx_make_model(graph))
 
 
+@pytest.mark.multifpga
+@pytest.mark.auroraflow
 @pytest.mark.parametrize("nodes", [1, 10, 100])
 @pytest.mark.parametrize("communication_kernel", [MFCommunicationKernel.AURORA])
 def test_metadata_sdp_only(nodes: int, communication_kernel: MFCommunicationKernel) -> None:
@@ -79,6 +81,8 @@ def test_metadata_sdp_only(nodes: int, communication_kernel: MFCommunicationKern
         )
 
 
+@pytest.mark.multifpga
+@pytest.mark.auroraflow
 @pytest.mark.parametrize("communication_kernel", [MFCommunicationKernel.AURORA])
 @pytest.mark.parametrize("topology", [MFTopology.CHAIN, MFTopology.RETURNCHAIN])
 def test_metadata(
@@ -161,6 +165,8 @@ def test_metadata(
             )
 
 
+@pytest.mark.multifpga
+@pytest.mark.auroraflow
 @pytest.mark.parametrize("communication_kernel", [MFCommunicationKernel.AURORA])
 def test_metadata_small(communication_kernel: MFCommunicationKernel) -> None:
     """Test metadata creation on hand-crafted small models."""

--- a/tests/fpgadataflow/multifpga/test_multifpga_partitioning.py
+++ b/tests/fpgadataflow/multifpga/test_multifpga_partitioning.py
@@ -24,6 +24,9 @@ def _dump(data: dict, name: str, path: Path) -> Path:
     return p
 
 
+@pytest.mark.multifpga
+@pytest.mark.slow
+@pytest.mark.vivado
 @pytest.mark.parametrize(
     "model_type",
     [

--- a/tests/fpgadataflow/multifpga/test_multifpga_resource_estimation.py
+++ b/tests/fpgadataflow/multifpga/test_multifpga_resource_estimation.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
 @pytest.mark.multifpga
 @pytest.mark.slow
+@pytest.mark.vivado
 @pytest.mark.parametrize(
     "platform", [("U55C", ShellFlowType.VITIS_ALVEO), ("Pynq-Z1", ShellFlowType.VIVADO_ZYNQ)]
 )

--- a/tests/fpgadataflow/multifpga/test_multifpga_sdp_creation.py
+++ b/tests/fpgadataflow/multifpga/test_multifpga_sdp_creation.py
@@ -217,6 +217,7 @@ def digraph_from_graph_definition(
     return g
 
 
+@pytest.mark.multifpga
 @pytest.mark.parametrize(
     "graph",
     [pytest.param(graph_data, id=graph_name) for graph_name, graph_data in test_graphs.items()],
@@ -278,6 +279,7 @@ def sdp_overview(model: ModelWrapper) -> str:
     return s
 
 
+@pytest.mark.multifpga
 @pytest.mark.parametrize(
     "graph",
     [pytest.param(graph_data, id=graph_name) for graph_name, graph_data in test_graphs.items()],
@@ -322,6 +324,7 @@ def test_iodma_separation(
             assert "IODMA" in submodel.graph.node[0].op_type
 
 
+@pytest.mark.multifpga
 @pytest.mark.parametrize(
     "graph",
     [pytest.param(graph_data, id=graph_name) for graph_name, graph_data in test_graphs.items()],


### PR DESCRIPTION
Correctly mark MultiFPGA tests, as well as slow and Vivado-requiring tests.